### PR TITLE
Fixes to Meta-framework list

### DIFF
--- a/initial-comparison-list.md
+++ b/initial-comparison-list.md
@@ -5,8 +5,7 @@
 - [Next.js](https://nextjs.org) - React
 - [Nuxt](https://nuxt.com) - Vue
 - [SvelteKit](https://kit.svelte.dev) - Svelte
-- [Remix](https://remix.run) - React (Preact in beta for new version)
-- [React Router](https://reactrouter.com) - React
+- [React Router](https://reactrouter.com) - React (was Remix, new Remix using Preact is in beta)
 - [Astro](https://astro.build) - Framework-agnostic
 - [SolidStart](https://start.solidjs.com) - Solid
 - [Qwik City](https://qwik.dev/docs/qwikcity/) - Qwik


### PR DESCRIPTION
- Qwiks meta-framework is actually Qwik City
- Remix now uses Preact

Based on feedback from https://github.com/e18e/framework-tracker/pull/2#discussion_r2649428496