### PR TITLE
Improve script

### DIFF
--- a/.github/workflows/generate-stats.yml
+++ b/.github/workflows/generate-stats.yml
@@ -5,7 +5,9 @@ on:
     branches: [main]
     paths:
       - 'packages/starter-*/**'
+      - '!packages/starter-*/.ci-stats.json'
       - 'packages/app-*/**'
+      - '!packages/app-*/.ci-stats.json'
       - 'packages/stats-generator/**'
       - '.github/workflows/generate-stats.yml'
       - '.github/frameworks.json'
@@ -172,7 +174,7 @@ jobs:
           fi
 
           git checkout -B automated-stats-update
-          git add .
+          git add packages/
           git commit -m "Update CI stats and generated stats after starter changes"
           git push --force-with-lease origin automated-stats-update
 
@@ -191,7 +193,5 @@ jobs:
           else
             echo "PR already exists, updated with new commits"
           fi
-
-          gh pr merge automated-stats-update --auto --squash --delete-branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Stop looping scripts on stat PR merge
- Changed git add . to git add packages/ - so only the actual package files are committed, not the temporary artifacts
- Removed the gh pr merge --auto --squash --delete-branch line - step keeps failing and it's fine for us to just merge the PR and double check what's being added. If there is a PR already open and it runs again it just updates the PR