### PR TITLE
Disclaimer text

### DIFF
--- a/packages/docs/src/components/DependencyStats.astro
+++ b/packages/docs/src/components/DependencyStats.astro
@@ -36,6 +36,10 @@ function formatBytesToMB(bytes: number): string {
 
       <h2>Dev Time Performance</h2>
 
+      <p class="methodology">
+        Measured using pnpm on GitHub Actions (ubuntu-latest, Node 24).
+      </p>
+
       <div class="table-wrapper">
         <table aria-label="Dependency counts by framework">
           <thead>
@@ -172,6 +176,12 @@ function formatBytesToMB(bytes: number): string {
     max-width: 700px;
   }
 
+  .methodology {
+    font-size: 14px;
+    color: #6b7280;
+    margin-bottom: 0.5em;
+  }
+
   .table-wrapper {
     width: 100%;
     margin-top: 16px;
@@ -290,6 +300,10 @@ function formatBytesToMB(bytes: number): string {
 
   :global(html.dark) .framework-links li {
     color: #ffffffde;
+  }
+
+  :global(html.dark) .methodology {
+    color: #ffffffa6;
   }
 
   :global(html.dark) .coming-soon {


### PR DESCRIPTION
Adding a slight disclaimer about how these stats come about. Also raises questions on making this fairer in the long run:

- Run each test a few times
- Use a larger runner with dedicated resources
- Run self-hosted runners 
- Other ideas that are not just off the top of my head......

<img width="1972" height="1394" alt="Screenshot 2026-01-25 at 7 27 40 pm" src="https://github.com/user-attachments/assets/f39d98b9-0c80-4ffa-a6d4-8c159156db10" />
