### PR TITLE
calculate build times avg min max

### DIFF
--- a/.github/workflows/generate-stats.yml
+++ b/.github/workflows/generate-stats.yml
@@ -97,7 +97,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run build benchmark
-        run: pnpm --filter @framework-tracker/stats-generator run:build ${{ matrix.framework.package }}
+        run: |
+          RUN_FREQUENCY=$(echo '${{ toJson(matrix.framework) }}' | jq -r '.measurements[] | select(.type == "build") | .runFrequency')
+          pnpm --filter @framework-tracker/stats-generator run:build ${{ matrix.framework.package }} $RUN_FREQUENCY
 
       - name: Upload build stats
         uses: actions/upload-artifact@v4

--- a/packages/docs/src/components/DependencyStats.astro
+++ b/packages/docs/src/components/DependencyStats.astro
@@ -90,8 +90,8 @@ function formatBytesToMB(bytes: number): string {
               <th scope="col">Avg Install</th>
               <th scope="col">Min Install</th>
               <th scope="col">Max Install</th>
-              <th scope="col">Cold Build</th>
-              <th scope="col">Warm Build</th>
+              <th scope="col">Avg Cold Build</th>
+              <th scope="col">Avg Warm Build</th>
               <th scope="col">Build Output</th>
             </tr>
           </thead>
@@ -100,11 +100,11 @@ function formatBytesToMB(bytes: number): string {
               starterStats.map((framework) => (
                 <tr>
                   <td class="framework-name">{framework.name}</td>
-                  <td>{(framework.avgInstallTimeMs / 1000).toFixed(2)}s</td>
-                  <td>{(framework.minInstallTimeMs / 1000).toFixed(2)}s</td>
-                  <td>{(framework.maxInstallTimeMs / 1000).toFixed(2)}s</td>
-                  <td>{(framework.coldBuildTimeMs / 1000).toFixed(2)}s</td>
-                  <td>{(framework.warmBuildTimeMs / 1000).toFixed(2)}s</td>
+                  <td>{(framework.installTime.avgMs / 1000).toFixed(2)}s</td>
+                  <td>{(framework.installTime.minMs / 1000).toFixed(2)}s</td>
+                  <td>{(framework.installTime.maxMs / 1000).toFixed(2)}s</td>
+                  <td>{(framework.coldBuildTime.avgMs / 1000).toFixed(2)}s</td>
+                  <td>{(framework.warmBuildTime.avgMs / 1000).toFixed(2)}s</td>
                   <td>{formatBytesToMB(framework.buildOutputSize)}</td>
                 </tr>
               ))

--- a/packages/docs/src/content/config.ts
+++ b/packages/docs/src/content/config.ts
@@ -1,5 +1,11 @@
 import { defineCollection, z } from 'astro:content'
 
+const timeSchema = z.object({
+  avgMs: z.number(),
+  minMs: z.number(),
+  maxMs: z.number(),
+})
+
 const devtimeCollection = defineCollection({
   type: 'data',
   schema: z.object({
@@ -8,11 +14,9 @@ const devtimeCollection = defineCollection({
     package: z.string(),
     prodDependencies: z.number(),
     devDependencies: z.number(),
-    avgInstallTimeMs: z.number(),
-    minInstallTimeMs: z.number(),
-    maxInstallTimeMs: z.number(),
-    coldBuildTimeMs: z.number(),
-    warmBuildTimeMs: z.number(),
+    installTime: timeSchema,
+    coldBuildTime: timeSchema,
+    warmBuildTime: timeSchema,
     buildOutputSize: z.number(),
     nodeModulesSize: z.number(),
     nodeModulesSizeProdOnly: z.number(),

--- a/packages/docs/src/content/devtime/starter-astro.json
+++ b/packages/docs/src/content/devtime/starter-astro.json
@@ -4,16 +4,31 @@
   "type": "starter-kit",
   "prodDependencies": 1,
   "devDependencies": 0,
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "installTimeMs": 3160,
   "coldBuildTimeMs": 2430,
   "warmBuildTimeMs": 2157,
   "buildOutputSize": 32768,
-  "nodeModulesSize": 205787136,
+  "nodeModulesSize": 205783040,
   "nodeModulesSizeProdOnly": 205783040,
   "frameworkVersion": "5.16.15",
-  "avgInstallTimeMs": 2126.2,
-  "minInstallTimeMs": 1791,
-  "maxInstallTimeMs": 2842
+  "avgInstallTimeMs": 2482.2,
+  "minInstallTimeMs": 2051,
+  "maxInstallTimeMs": 3738,
+  "coldBuildTime": {
+    "avgMs": 2171.6,
+    "minMs": 2118,
+    "maxMs": 2247
+  },
+  "warmBuildTime": {
+    "avgMs": 2130.8,
+    "minMs": 2117,
+    "maxMs": 2162
+  },
+  "installTime": {
+    "avgMs": 2670.4,
+    "minMs": 2154,
+    "maxMs": 4250
+  }
 }

--- a/packages/docs/src/content/devtime/starter-next-js.json
+++ b/packages/docs/src/content/devtime/starter-next-js.json
@@ -8,12 +8,27 @@
   "coldBuildTimeMs": 7045,
   "warmBuildTimeMs": 7188,
   "buildOutputSize": 6426624,
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "nodeModulesSize": 586166272,
-  "nodeModulesSizeProdOnly": 457179136,
+  "nodeModulesSizeProdOnly": 457183232,
   "frameworkVersion": "16.1.1",
-  "avgInstallTimeMs": 2368.4,
-  "minInstallTimeMs": 1646,
-  "maxInstallTimeMs": 5099
+  "avgInstallTimeMs": 4198,
+  "minInstallTimeMs": 3414,
+  "maxInstallTimeMs": 6993,
+  "coldBuildTime": {
+    "avgMs": 6922.2,
+    "minMs": 6871,
+    "maxMs": 7017
+  },
+  "warmBuildTime": {
+    "avgMs": 7165.8,
+    "minMs": 6811,
+    "maxMs": 8077
+  },
+  "installTime": {
+    "avgMs": 4020,
+    "minMs": 3345,
+    "maxMs": 6468
+  }
 }

--- a/packages/docs/src/content/devtime/starter-nuxt.json
+++ b/packages/docs/src/content/devtime/starter-nuxt.json
@@ -8,12 +8,27 @@
   "coldBuildTimeMs": 6428,
   "warmBuildTimeMs": 6132,
   "buildOutputSize": 2461696,
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "nodeModulesSize": 255066112,
   "nodeModulesSizeProdOnly": 255053824,
   "frameworkVersion": "4.2.2",
-  "avgInstallTimeMs": 4696.6,
-  "minInstallTimeMs": 4025,
-  "maxInstallTimeMs": 7212
+  "avgInstallTimeMs": 5070,
+  "minInstallTimeMs": 4335,
+  "maxInstallTimeMs": 7793,
+  "coldBuildTime": {
+    "avgMs": 6207.2,
+    "minMs": 6045,
+    "maxMs": 6628
+  },
+  "warmBuildTime": {
+    "avgMs": 6110.8,
+    "minMs": 6057,
+    "maxMs": 6189
+  },
+  "installTime": {
+    "avgMs": 4901.6,
+    "minMs": 4003,
+    "maxMs": 7989
+  }
 }

--- a/packages/docs/src/content/devtime/starter-react-router.json
+++ b/packages/docs/src/content/devtime/starter-react-router.json
@@ -8,12 +8,27 @@
   "coldBuildTimeMs": 2796,
   "warmBuildTimeMs": 2687,
   "buildOutputSize": 397312,
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "nodeModulesSize": 141660160,
   "nodeModulesSizeProdOnly": 42184704,
   "frameworkVersion": "7.10.1",
-  "avgInstallTimeMs": 1796.4,
-  "minInstallTimeMs": 1437,
-  "maxInstallTimeMs": 2945
+  "avgInstallTimeMs": 1983.2,
+  "minInstallTimeMs": 1587,
+  "maxInstallTimeMs": 3343,
+  "coldBuildTime": {
+    "avgMs": 2752.8,
+    "minMs": 2617,
+    "maxMs": 3045
+  },
+  "warmBuildTime": {
+    "avgMs": 2649.2,
+    "minMs": 2620,
+    "maxMs": 2673
+  },
+  "installTime": {
+    "avgMs": 1985.8,
+    "minMs": 1640,
+    "maxMs": 3315
+  }
 }

--- a/packages/docs/src/content/devtime/starter-solid-start.json
+++ b/packages/docs/src/content/devtime/starter-solid-start.json
@@ -4,16 +4,31 @@
   "type": "starter-kit",
   "prodDependencies": 5,
   "devDependencies": 0,
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "installTimeMs": 3935,
-  "nodeModulesSize": 191254528,
+  "nodeModulesSize": 191250432,
   "nodeModulesSizeProdOnly": 191250432,
-  "coldBuildTimeMs": 9128,
-  "warmBuildTimeMs": 9111,
+  "coldBuildTimeMs": 9919,
+  "warmBuildTimeMs": 9551,
   "buildOutputSize": 888832,
   "frameworkVersion": "1.2.1",
-  "avgInstallTimeMs": 2689.8,
-  "minInstallTimeMs": 2319,
-  "maxInstallTimeMs": 4083
+  "avgInstallTimeMs": 3066.2,
+  "minInstallTimeMs": 2586,
+  "maxInstallTimeMs": 4638,
+  "coldBuildTime": {
+    "avgMs": 8415.2,
+    "minMs": 8325,
+    "maxMs": 8486
+  },
+  "warmBuildTime": {
+    "avgMs": 8447.4,
+    "minMs": 8369,
+    "maxMs": 8523
+  },
+  "installTime": {
+    "avgMs": 3269.2,
+    "minMs": 2765,
+    "maxMs": 5101
+  }
 }

--- a/packages/docs/src/content/devtime/starter-sveltekit.json
+++ b/packages/docs/src/content/devtime/starter-sveltekit.json
@@ -8,12 +8,27 @@
   "coldBuildTimeMs": 3933,
   "warmBuildTimeMs": 3532,
   "buildOutputSize": 1343488,
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "nodeModulesSize": 95031296,
   "nodeModulesSizeProdOnly": 24576,
   "frameworkVersion": "2.49.4",
-  "avgInstallTimeMs": 2025.6,
-  "minInstallTimeMs": 1841,
-  "maxInstallTimeMs": 2450
+  "avgInstallTimeMs": 2195,
+  "minInstallTimeMs": 1945,
+  "maxInstallTimeMs": 2904,
+  "coldBuildTime": {
+    "avgMs": 4171.4,
+    "minMs": 4031,
+    "maxMs": 4369
+  },
+  "warmBuildTime": {
+    "avgMs": 4050.2,
+    "minMs": 3982,
+    "maxMs": 4230
+  },
+  "installTime": {
+    "avgMs": 2223.8,
+    "minMs": 1876,
+    "maxMs": 3017
+  }
 }

--- a/packages/docs/src/content/devtime/starter-tanstack-start-react.json
+++ b/packages/docs/src/content/devtime/starter-tanstack-start-react.json
@@ -8,12 +8,27 @@
   "coldBuildTimeMs": 8075,
   "warmBuildTimeMs": 7574,
   "buildOutputSize": 2134016,
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
-  "nodeModulesSize": 278102016,
-  "nodeModulesSizeProdOnly": 244027392,
+  "nodeModulesSize": 278106112,
+  "nodeModulesSizeProdOnly": 244031488,
   "frameworkVersion": "1.145.3",
-  "avgInstallTimeMs": 2867,
-  "minInstallTimeMs": 2376,
-  "maxInstallTimeMs": 4798
+  "avgInstallTimeMs": 3204.4,
+  "minInstallTimeMs": 2522,
+  "maxInstallTimeMs": 5487,
+  "coldBuildTime": {
+    "avgMs": 8167.8,
+    "minMs": 7809,
+    "maxMs": 8916
+  },
+  "warmBuildTime": {
+    "avgMs": 8038,
+    "minMs": 8006,
+    "maxMs": 8061
+  },
+  "installTime": {
+    "avgMs": 3052.8,
+    "minMs": 2471,
+    "maxMs": 5233
+  }
 }

--- a/packages/starter-astro/ci-stats.json
+++ b/packages/starter-astro/ci-stats.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "5.16.15",
-  "avgInstallTimeMs": 2126.2,
-  "minInstallTimeMs": 1791,
-  "maxInstallTimeMs": 2842,
-  "nodeModulesSize": 205787136,
+  "avgInstallTimeMs": 2482.2,
+  "minInstallTimeMs": 2051,
+  "maxInstallTimeMs": 3738,
+  "nodeModulesSize": 205783040,
   "nodeModulesSizeProdOnly": 205783040,
-  "coldBuildTimeMs": 2430,
-  "warmBuildTimeMs": 2157,
-  "buildOutputSize": 32768
+  "coldBuildTimeMs": 2595,
+  "warmBuildTimeMs": 2117,
+  "buildOutputSize": 32768,
+  "coldBuildTime": {
+    "avgMs": 2171.6,
+    "minMs": 2118,
+    "maxMs": 2247
+  },
+  "warmBuildTime": {
+    "avgMs": 2130.8,
+    "minMs": 2117,
+    "maxMs": 2162
+  },
+  "installTime": {
+    "avgMs": 2670.4,
+    "minMs": 2154,
+    "maxMs": 4250
+  }
 }

--- a/packages/starter-astro/stats/5.16.15.json
+++ b/packages/starter-astro/stats/5.16.15.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "5.16.15",
-  "avgInstallTimeMs": 2126.2,
-  "minInstallTimeMs": 1791,
-  "maxInstallTimeMs": 2842,
-  "nodeModulesSize": 205787136,
+  "avgInstallTimeMs": 2482.2,
+  "minInstallTimeMs": 2051,
+  "maxInstallTimeMs": 3738,
+  "nodeModulesSize": 205783040,
   "nodeModulesSizeProdOnly": 205783040,
-  "coldBuildTimeMs": 2430,
-  "warmBuildTimeMs": 2157,
-  "buildOutputSize": 32768
+  "coldBuildTimeMs": 2595,
+  "warmBuildTimeMs": 2117,
+  "buildOutputSize": 32768,
+  "coldBuildTime": {
+    "avgMs": 2171.6,
+    "minMs": 2118,
+    "maxMs": 2247
+  },
+  "warmBuildTime": {
+    "avgMs": 2130.8,
+    "minMs": 2117,
+    "maxMs": 2162
+  },
+  "installTime": {
+    "avgMs": 2670.4,
+    "minMs": 2154,
+    "maxMs": 4250
+  }
 }

--- a/packages/starter-next-js/ci-stats.json
+++ b/packages/starter-next-js/ci-stats.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "16.1.1",
-  "avgInstallTimeMs": 2368.4,
-  "minInstallTimeMs": 1646,
-  "maxInstallTimeMs": 5099,
+  "avgInstallTimeMs": 4198,
+  "minInstallTimeMs": 3414,
+  "maxInstallTimeMs": 6993,
   "nodeModulesSize": 586166272,
-  "nodeModulesSizeProdOnly": 457179136,
-  "coldBuildTimeMs": 7045,
-  "warmBuildTimeMs": 7188,
-  "buildOutputSize": 6426624
+  "nodeModulesSizeProdOnly": 457183232,
+  "coldBuildTimeMs": 7159,
+  "warmBuildTimeMs": 7159,
+  "buildOutputSize": 6426624,
+  "coldBuildTime": {
+    "avgMs": 6922.2,
+    "minMs": 6871,
+    "maxMs": 7017
+  },
+  "warmBuildTime": {
+    "avgMs": 7165.8,
+    "minMs": 6811,
+    "maxMs": 8077
+  },
+  "installTime": {
+    "avgMs": 4020,
+    "minMs": 3345,
+    "maxMs": 6468
+  }
 }

--- a/packages/starter-next-js/stats/16.1.1.json
+++ b/packages/starter-next-js/stats/16.1.1.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "16.1.1",
-  "avgInstallTimeMs": 2368.4,
-  "minInstallTimeMs": 1646,
-  "maxInstallTimeMs": 5099,
+  "avgInstallTimeMs": 4198,
+  "minInstallTimeMs": 3414,
+  "maxInstallTimeMs": 6993,
   "nodeModulesSize": 586166272,
-  "nodeModulesSizeProdOnly": 457179136,
-  "coldBuildTimeMs": 7045,
-  "warmBuildTimeMs": 7188,
-  "buildOutputSize": 6426624
+  "nodeModulesSizeProdOnly": 457183232,
+  "coldBuildTimeMs": 7159,
+  "warmBuildTimeMs": 7159,
+  "buildOutputSize": 6426624,
+  "coldBuildTime": {
+    "avgMs": 6922.2,
+    "minMs": 6871,
+    "maxMs": 7017
+  },
+  "warmBuildTime": {
+    "avgMs": 7165.8,
+    "minMs": 6811,
+    "maxMs": 8077
+  },
+  "installTime": {
+    "avgMs": 4020,
+    "minMs": 3345,
+    "maxMs": 6468
+  }
 }

--- a/packages/starter-nuxt/ci-stats.json
+++ b/packages/starter-nuxt/ci-stats.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "4.2.2",
-  "avgInstallTimeMs": 4696.6,
-  "minInstallTimeMs": 4025,
-  "maxInstallTimeMs": 7212,
+  "avgInstallTimeMs": 5070,
+  "minInstallTimeMs": 4335,
+  "maxInstallTimeMs": 7793,
   "nodeModulesSize": 255066112,
   "nodeModulesSizeProdOnly": 255053824,
-  "coldBuildTimeMs": 6428,
-  "warmBuildTimeMs": 6132,
-  "buildOutputSize": 2461696
+  "coldBuildTimeMs": 6962,
+  "warmBuildTimeMs": 6545,
+  "buildOutputSize": 2461696,
+  "coldBuildTime": {
+    "avgMs": 6207.2,
+    "minMs": 6045,
+    "maxMs": 6628
+  },
+  "warmBuildTime": {
+    "avgMs": 6110.8,
+    "minMs": 6057,
+    "maxMs": 6189
+  },
+  "installTime": {
+    "avgMs": 4901.6,
+    "minMs": 4003,
+    "maxMs": 7989
+  }
 }

--- a/packages/starter-nuxt/stats/4.2.2.json
+++ b/packages/starter-nuxt/stats/4.2.2.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "4.2.2",
-  "avgInstallTimeMs": 4696.6,
-  "minInstallTimeMs": 4025,
-  "maxInstallTimeMs": 7212,
+  "avgInstallTimeMs": 5070,
+  "minInstallTimeMs": 4335,
+  "maxInstallTimeMs": 7793,
   "nodeModulesSize": 255066112,
   "nodeModulesSizeProdOnly": 255053824,
-  "coldBuildTimeMs": 6428,
-  "warmBuildTimeMs": 6132,
-  "buildOutputSize": 2461696
+  "coldBuildTimeMs": 6962,
+  "warmBuildTimeMs": 6545,
+  "buildOutputSize": 2461696,
+  "coldBuildTime": {
+    "avgMs": 6207.2,
+    "minMs": 6045,
+    "maxMs": 6628
+  },
+  "warmBuildTime": {
+    "avgMs": 6110.8,
+    "minMs": 6057,
+    "maxMs": 6189
+  },
+  "installTime": {
+    "avgMs": 4901.6,
+    "minMs": 4003,
+    "maxMs": 7989
+  }
 }

--- a/packages/starter-react-router/ci-stats.json
+++ b/packages/starter-react-router/ci-stats.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "7.10.1",
-  "avgInstallTimeMs": 1796.4,
-  "minInstallTimeMs": 1437,
-  "maxInstallTimeMs": 2945,
+  "avgInstallTimeMs": 1983.2,
+  "minInstallTimeMs": 1587,
+  "maxInstallTimeMs": 3343,
   "nodeModulesSize": 141660160,
   "nodeModulesSizeProdOnly": 42184704,
-  "coldBuildTimeMs": 2796,
-  "warmBuildTimeMs": 2687,
-  "buildOutputSize": 397312
+  "coldBuildTimeMs": 2747,
+  "warmBuildTimeMs": 2746,
+  "buildOutputSize": 397312,
+  "coldBuildTime": {
+    "avgMs": 2752.8,
+    "minMs": 2617,
+    "maxMs": 3045
+  },
+  "warmBuildTime": {
+    "avgMs": 2649.2,
+    "minMs": 2620,
+    "maxMs": 2673
+  },
+  "installTime": {
+    "avgMs": 1985.8,
+    "minMs": 1640,
+    "maxMs": 3315
+  }
 }

--- a/packages/starter-react-router/stats/7.10.1.json
+++ b/packages/starter-react-router/stats/7.10.1.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "7.10.1",
-  "avgInstallTimeMs": 1796.4,
-  "minInstallTimeMs": 1437,
-  "maxInstallTimeMs": 2945,
+  "avgInstallTimeMs": 1983.2,
+  "minInstallTimeMs": 1587,
+  "maxInstallTimeMs": 3343,
   "nodeModulesSize": 141660160,
   "nodeModulesSizeProdOnly": 42184704,
-  "coldBuildTimeMs": 2796,
-  "warmBuildTimeMs": 2687,
-  "buildOutputSize": 397312
+  "coldBuildTimeMs": 2747,
+  "warmBuildTimeMs": 2746,
+  "buildOutputSize": 397312,
+  "coldBuildTime": {
+    "avgMs": 2752.8,
+    "minMs": 2617,
+    "maxMs": 3045
+  },
+  "warmBuildTime": {
+    "avgMs": 2649.2,
+    "minMs": 2620,
+    "maxMs": 2673
+  },
+  "installTime": {
+    "avgMs": 1985.8,
+    "minMs": 1640,
+    "maxMs": 3315
+  }
 }

--- a/packages/starter-solid-start/ci-stats.json
+++ b/packages/starter-solid-start/ci-stats.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "1.2.1",
-  "avgInstallTimeMs": 2689.8,
-  "minInstallTimeMs": 2319,
-  "maxInstallTimeMs": 4083,
-  "nodeModulesSize": 191254528,
+  "avgInstallTimeMs": 3066.2,
+  "minInstallTimeMs": 2586,
+  "maxInstallTimeMs": 4638,
+  "nodeModulesSize": 191250432,
   "nodeModulesSizeProdOnly": 191250432,
-  "coldBuildTimeMs": 9128,
-  "warmBuildTimeMs": 9111,
-  "buildOutputSize": 888832
+  "coldBuildTimeMs": 9919,
+  "warmBuildTimeMs": 9551,
+  "buildOutputSize": 888832,
+  "coldBuildTime": {
+    "avgMs": 8415.2,
+    "minMs": 8325,
+    "maxMs": 8486
+  },
+  "warmBuildTime": {
+    "avgMs": 8447.4,
+    "minMs": 8369,
+    "maxMs": 8523
+  },
+  "installTime": {
+    "avgMs": 3269.2,
+    "minMs": 2765,
+    "maxMs": 5101
+  }
 }

--- a/packages/starter-solid-start/stats/1.2.1.json
+++ b/packages/starter-solid-start/stats/1.2.1.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "1.2.1",
-  "avgInstallTimeMs": 2689.8,
-  "minInstallTimeMs": 2319,
-  "maxInstallTimeMs": 4083,
-  "nodeModulesSize": 191254528,
+  "avgInstallTimeMs": 3066.2,
+  "minInstallTimeMs": 2586,
+  "maxInstallTimeMs": 4638,
+  "nodeModulesSize": 191250432,
   "nodeModulesSizeProdOnly": 191250432,
-  "coldBuildTimeMs": 9128,
-  "warmBuildTimeMs": 9111,
-  "buildOutputSize": 888832
+  "coldBuildTimeMs": 9919,
+  "warmBuildTimeMs": 9551,
+  "buildOutputSize": 888832,
+  "coldBuildTime": {
+    "avgMs": 8415.2,
+    "minMs": 8325,
+    "maxMs": 8486
+  },
+  "warmBuildTime": {
+    "avgMs": 8447.4,
+    "minMs": 8369,
+    "maxMs": 8523
+  },
+  "installTime": {
+    "avgMs": 3269.2,
+    "minMs": 2765,
+    "maxMs": 5101
+  }
 }

--- a/packages/starter-sveltekit/ci-stats.json
+++ b/packages/starter-sveltekit/ci-stats.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "2.49.4",
-  "avgInstallTimeMs": 2025.6,
-  "minInstallTimeMs": 1841,
-  "maxInstallTimeMs": 2450,
-  "nodeModulesSize": 95031296,
-  "nodeModulesSizeProdOnly": 24576,
-  "coldBuildTimeMs": 3933,
-  "warmBuildTimeMs": 3532,
-  "buildOutputSize": 1343488
+  "avgInstallTimeMs": 2195,
+  "minInstallTimeMs": 1945,
+  "maxInstallTimeMs": 2904,
+  "nodeModulesSize": 95027200,
+  "nodeModulesSizeProdOnly": 20480,
+  "coldBuildTimeMs": 4220,
+  "warmBuildTimeMs": 3910,
+  "buildOutputSize": 1343488,
+  "coldBuildTime": {
+    "avgMs": 4171.4,
+    "minMs": 4031,
+    "maxMs": 4369
+  },
+  "warmBuildTime": {
+    "avgMs": 4050.2,
+    "minMs": 3982,
+    "maxMs": 4230
+  },
+  "installTime": {
+    "avgMs": 2223.8,
+    "minMs": 1876,
+    "maxMs": 3017
+  }
 }

--- a/packages/starter-sveltekit/stats/2.49.4.json
+++ b/packages/starter-sveltekit/stats/2.49.4.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "2.49.4",
-  "avgInstallTimeMs": 2025.6,
-  "minInstallTimeMs": 1841,
-  "maxInstallTimeMs": 2450,
-  "nodeModulesSize": 95031296,
-  "nodeModulesSizeProdOnly": 24576,
-  "coldBuildTimeMs": 3933,
-  "warmBuildTimeMs": 3532,
-  "buildOutputSize": 1343488
+  "avgInstallTimeMs": 2195,
+  "minInstallTimeMs": 1945,
+  "maxInstallTimeMs": 2904,
+  "nodeModulesSize": 95027200,
+  "nodeModulesSizeProdOnly": 20480,
+  "coldBuildTimeMs": 4220,
+  "warmBuildTimeMs": 3910,
+  "buildOutputSize": 1343488,
+  "coldBuildTime": {
+    "avgMs": 4171.4,
+    "minMs": 4031,
+    "maxMs": 4369
+  },
+  "warmBuildTime": {
+    "avgMs": 4050.2,
+    "minMs": 3982,
+    "maxMs": 4230
+  },
+  "installTime": {
+    "avgMs": 2223.8,
+    "minMs": 1876,
+    "maxMs": 3017
+  }
 }

--- a/packages/starter-tanstack-start-react/ci-stats.json
+++ b/packages/starter-tanstack-start-react/ci-stats.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "1.145.3",
-  "avgInstallTimeMs": 2867,
-  "minInstallTimeMs": 2376,
-  "maxInstallTimeMs": 4798,
-  "nodeModulesSize": 278102016,
-  "nodeModulesSizeProdOnly": 244027392,
-  "coldBuildTimeMs": 8075,
-  "warmBuildTimeMs": 7574,
-  "buildOutputSize": 2134016
+  "avgInstallTimeMs": 3204.4,
+  "minInstallTimeMs": 2522,
+  "maxInstallTimeMs": 5487,
+  "nodeModulesSize": 278106112,
+  "nodeModulesSizeProdOnly": 244031488,
+  "coldBuildTimeMs": 9098,
+  "warmBuildTimeMs": 8359,
+  "buildOutputSize": 2134016,
+  "coldBuildTime": {
+    "avgMs": 8167.8,
+    "minMs": 7809,
+    "maxMs": 8916
+  },
+  "warmBuildTime": {
+    "avgMs": 8038,
+    "minMs": 8006,
+    "maxMs": 8061
+  },
+  "installTime": {
+    "avgMs": 3052.8,
+    "minMs": 2471,
+    "maxMs": 5233
+  }
 }

--- a/packages/starter-tanstack-start-react/stats/1.145.3.json
+++ b/packages/starter-tanstack-start-react/stats/1.145.3.json
@@ -1,13 +1,28 @@
 {
-  "timingMeasuredAt": "2026-02-07T11:09:22.757Z",
+  "timingMeasuredAt": "2026-02-06T23:02:57.132Z",
   "runner": "ubuntu-latest",
   "frameworkVersion": "1.145.3",
-  "avgInstallTimeMs": 2867,
-  "minInstallTimeMs": 2376,
-  "maxInstallTimeMs": 4798,
-  "nodeModulesSize": 278102016,
-  "nodeModulesSizeProdOnly": 244027392,
-  "coldBuildTimeMs": 8075,
-  "warmBuildTimeMs": 7574,
-  "buildOutputSize": 2134016
+  "avgInstallTimeMs": 3204.4,
+  "minInstallTimeMs": 2522,
+  "maxInstallTimeMs": 5487,
+  "nodeModulesSize": 278106112,
+  "nodeModulesSizeProdOnly": 244031488,
+  "coldBuildTimeMs": 9098,
+  "warmBuildTimeMs": 8359,
+  "buildOutputSize": 2134016,
+  "coldBuildTime": {
+    "avgMs": 8167.8,
+    "minMs": 7809,
+    "maxMs": 8916
+  },
+  "warmBuildTime": {
+    "avgMs": 8038,
+    "minMs": 8006,
+    "maxMs": 8061
+  },
+  "installTime": {
+    "avgMs": 3052.8,
+    "minMs": 2471,
+    "maxMs": 5233
+  }
 }

--- a/packages/stats-generator/src/run-install-benchmark.ts
+++ b/packages/stats-generator/src/run-install-benchmark.ts
@@ -65,7 +65,10 @@ async function main() {
   const { packageName, args } = parseArgs(
     'Usage: run-install-benchmark <package-name> [run-frequency]\nExample: run-install-benchmark starter-astro 5',
   )
-  const runFrequency = parseInt(args[0] || '5', 10)
+
+  const fallbackFrequency = '5'
+  const base = 10
+  const runFrequency = parseInt(args[0] || fallbackFrequency, base)
 
   const framework = await getFrameworkByPackage(packageName)
 
@@ -130,9 +133,11 @@ async function main() {
 
     const stats: InstallStats = {
       frameworkVersion,
-      avgInstallTimeMs,
-      minInstallTimeMs,
-      maxInstallTimeMs,
+      installTime: {
+        avgMs: avgInstallTimeMs,
+        minMs: minInstallTimeMs,
+        maxMs: maxInstallTimeMs,
+      },
       nodeModulesSize,
       nodeModulesSizeProdOnly,
     }
@@ -141,9 +146,9 @@ async function main() {
     writeJsonFile(outputPath, stats)
 
     console.info(`\n✓ Saved install stats to ${outputPath}`)
-    console.info(`  Average: ${stats.avgInstallTimeMs}ms`)
-    console.info(`  Min: ${stats.minInstallTimeMs}ms`)
-    console.info(`  Max: ${stats.maxInstallTimeMs}ms`)
+    console.info(`  Average: ${stats.installTime.avgMs}ms`)
+    console.info(`  Min: ${stats.installTime.minMs}ms`)
+    console.info(`  Max: ${stats.installTime.maxMs}ms`)
   } finally {
     rmSync(tempDir, { recursive: true, force: true })
   }

--- a/packages/stats-generator/src/save-ci-stats.ts
+++ b/packages/stats-generator/src/save-ci-stats.ts
@@ -46,9 +46,7 @@ async function main() {
         stats = {
           ...stats,
           frameworkVersion: installStats.frameworkVersion,
-          avgInstallTimeMs: installStats.avgInstallTimeMs,
-          minInstallTimeMs: installStats.minInstallTimeMs,
-          maxInstallTimeMs: installStats.maxInstallTimeMs,
+          installTime: installStats.installTime,
           nodeModulesSize: installStats.nodeModulesSize,
           nodeModulesSizeProdOnly: installStats.nodeModulesSizeProdOnly,
         }
@@ -71,8 +69,8 @@ async function main() {
         console.info(`  ✓ Found build stats artifact`)
         stats = {
           ...stats,
-          coldBuildTimeMs: buildStats.coldBuildTimeMs,
-          warmBuildTimeMs: buildStats.warmBuildTimeMs,
+          coldBuildTime: buildStats.coldBuildTime,
+          warmBuildTime: buildStats.warmBuildTime,
           buildOutputSize: buildStats.buildOutputSize,
         }
       } else {

--- a/packages/stats-generator/src/schemas.ts
+++ b/packages/stats-generator/src/schemas.ts
@@ -1,17 +1,21 @@
 import { z } from 'zod'
 
+export const TimeStatSchema = z.object({
+  avgMs: z.number(),
+  minMs: z.number(),
+  maxMs: z.number(),
+})
+
 export const InstallStatsSchema = z.object({
   frameworkVersion: z.string().min(1),
-  avgInstallTimeMs: z.number().nonnegative(),
-  minInstallTimeMs: z.number().nonnegative(),
-  maxInstallTimeMs: z.number().nonnegative(),
+  installTime: TimeStatSchema,
   nodeModulesSize: z.number().nonnegative(),
   nodeModulesSizeProdOnly: z.number().nonnegative(),
 })
 
 export const BuildStatsSchema = z.object({
-  coldBuildTimeMs: z.number().nonnegative(),
-  warmBuildTimeMs: z.number().nonnegative(),
+  coldBuildTime: TimeStatSchema,
+  warmBuildTime: TimeStatSchema,
   buildOutputSize: z.number().nonnegative(),
 })
 
@@ -29,3 +33,4 @@ export const SSRStatsSchema = z.object({
 export type InstallStats = z.infer<typeof InstallStatsSchema>
 export type BuildStats = z.infer<typeof BuildStatsSchema>
 export type SSRStats = z.infer<typeof SSRStatsSchema>
+export type TimeStat = z.infer<typeof TimeStatSchema>

--- a/packages/stats-generator/src/types.ts
+++ b/packages/stats-generator/src/types.ts
@@ -24,14 +24,12 @@ export interface CIStats {
   runner?: string
   frameworkVersion?: string
   // Install stats
-  avgInstallTimeMs?: number
-  minInstallTimeMs?: number
-  maxInstallTimeMs?: number
+  installTime?: TimeStat
   nodeModulesSize?: number
   nodeModulesSizeProdOnly?: number
   // Build stats
-  coldBuildTimeMs?: number
-  warmBuildTimeMs?: number
+  coldBuildTime?: TimeStat
+  warmBuildTime?: TimeStat
   buildOutputSize?: number
   testTimeMs?: number
   // SSR stats
@@ -44,17 +42,21 @@ export interface CIStats {
 
 export interface InstallStats {
   frameworkVersion: string
-  avgInstallTimeMs: number
-  minInstallTimeMs: number
-  maxInstallTimeMs: number
+  installTime: TimeStat
   nodeModulesSize: number
   nodeModulesSizeProdOnly: number
 }
 
 export interface BuildStats {
-  coldBuildTimeMs: number
-  warmBuildTimeMs: number
+  coldBuildTime: TimeStat
+  warmBuildTime: TimeStat
   buildOutputSize: number
+}
+
+export interface TimeStat {
+  avgMs: number
+  minMs: number
+  maxMs: number
 }
 
 export interface FrameworkStats extends CIStats {


### PR DESCRIPTION
This PR calculates the build times Average, Min and Max and is part 2/2 for https://github.com/e18e/framework-tracker/issues/50
I have refactored some of the types and included a new `TimeStat` type that groups all time statistics together and refactored the install times to use this new type.

I have left out the min and max build times in the table as the addition of 4 extra columns made the table very noisy and congested. Can look at adding this in another PR just might have to rethink how we display it.

<img width="916" height="471" alt="Screenshot 2026-02-07 at 10 08 33 am" src="https://github.com/user-attachments/assets/5df13cfb-f728-4b95-a5d3-866f74f4e7a4" />
