### PR TITLE
Fix wording around Remix 3

### DIFF
--- a/initial-comparison-list.md
+++ b/initial-comparison-list.md
@@ -5,7 +5,7 @@
 - [Next.js](https://nextjs.org) - React
 - [Nuxt](https://nuxt.com) - Vue
 - [SvelteKit](https://kit.svelte.dev) - Svelte
-- [React Router](https://reactrouter.com) - React (was Remix, new Remix using Preact is in beta)
+- [React Router](https://reactrouter.com) - React (was Remix, new Remix not using React is in alpha)
 - [Astro](https://astro.build) - Framework-agnostic
 - [SolidStart](https://start.solidjs.com) - Solid
 - [Qwik City](https://qwik.dev/docs/qwikcity/) - Qwik


### PR DESCRIPTION
The new Remix (Remix v3) is

1. Not using Preact; it's using its own custom vDOM reconciler ([@remix-run/component](https://npmx.dev/package/@remix-run/component))
2. In [alpha](https://github.com/remix-run/remix/blob/main/packages/remix/CHANGELOG.md), not beta

Made some changes in initial-comparison-list.md to correct this wording