### PR TITLE
Set up MPA routes in App Packages

### DIFF
--- a/packages/app-astro/src/pages/mpa.astro
+++ b/packages/app-astro/src/pages/mpa.astro
@@ -1,8 +1,6 @@
 ---
-const entries = Array.from({ length: 1000 }, () => ({
-  id: crypto.randomUUID(),
-  name: crypto.randomUUID(),
-}))
+import { testData } from '../../../testdata/src/ssr'
+const entries = await testData()
 ---
 
 <html lang="en">

--- a/packages/app-astro/src/pages/mpa.astro
+++ b/packages/app-astro/src/pages/mpa.astro
@@ -1,0 +1,31 @@
+---
+const entries = Array.from({ length: 1000 }, () => ({
+  id: crypto.randomUUID(),
+  name: crypto.randomUUID(),
+}))
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Astro MPA Benchmark</title>
+  </head>
+  <body>
+    <table>
+      <tbody>
+        {
+          entries.map((entry) => (
+            <tr>
+              <td>{entry.id}</td>
+              <td>{entry.name}</td>
+              <td>
+                <a href={`/mpa/detail?id=${entry.id}`}>View →</a>
+              </td>
+            </tr>
+          ))
+        }
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/app-astro/src/pages/mpa/detail.astro
+++ b/packages/app-astro/src/pages/mpa/detail.astro
@@ -1,0 +1,14 @@
+---
+const id = Astro.url.searchParams.get('id')
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Astro MPA Detail</title>
+  </head>
+  <body>
+    <p id="detail-id">{id}</p>
+  </body>
+</html>

--- a/packages/app-next-js/app/mpa/detail/page.tsx
+++ b/packages/app-next-js/app/mpa/detail/page.tsx
@@ -1,0 +1,9 @@
+interface Props {
+  searchParams: Promise<{ id?: string }>
+}
+
+export default async function MpaDetailPage({ searchParams }: Props) {
+  const { id } = await searchParams
+
+  return <p id="detail-id">{id}</p>
+}

--- a/packages/app-next-js/app/mpa/page.tsx
+++ b/packages/app-next-js/app/mpa/page.tsx
@@ -1,0 +1,23 @@
+import { testData } from '../../../testdata/src/ssr'
+
+export const dynamic = 'force-dynamic'
+
+export default async function MpaPage() {
+  const entries = await testData()
+
+  return (
+    <table>
+      <tbody>
+        {entries.map((entry) => (
+          <tr key={entry.id}>
+            <td>{entry.id}</td>
+            <td>{entry.name}</td>
+            <td>
+              <a href={`/mpa/detail?id=${entry.id}`}>View →</a>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/packages/app-nuxt/app/pages/mpa/detail.vue
+++ b/packages/app-nuxt/app/pages/mpa/detail.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+const route = useRoute()
+const id = Array.isArray(route.query.id) ? route.query.id[0] : route.query.id
+</script>
+
+<template>
+  <p id="detail-id">{{ id }}</p>
+</template>

--- a/packages/app-nuxt/app/pages/mpa/index.vue
+++ b/packages/app-nuxt/app/pages/mpa/index.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { testData } from '../../../../testdata/src/ssr'
+
+const { data } = await useAsyncData(() => testData(), { deep: false })
+</script>
+
+<template>
+  <table>
+    <tbody>
+      <tr v-for="entry in data" :key="entry.id">
+        <td>{{ entry.id }}</td>
+        <td>{{ entry.name }}</td>
+        <td>
+          <a :href="`/mpa/detail?id=${entry.id}`">View →</a>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>

--- a/packages/app-react-router/app/routes.ts
+++ b/packages/app-react-router/app/routes.ts
@@ -6,4 +6,6 @@ export default [
   ...(isSpa ? [] : [index('routes/home.tsx')]),
   route('/spa', 'routes/spa.tsx'),
   route('/spa/detail', 'routes/spa.detail.tsx'),
+  route('/mpa', 'routes/mpa.tsx'),
+  route('/mpa/detail', 'routes/mpa.detail.tsx'),
 ] satisfies RouteConfig

--- a/packages/app-react-router/app/routes.ts
+++ b/packages/app-react-router/app/routes.ts
@@ -6,6 +6,10 @@ export default [
   ...(isSpa ? [] : [index('routes/home.tsx')]),
   route('/spa', 'routes/spa.tsx'),
   route('/spa/detail', 'routes/spa.detail.tsx'),
-  route('/mpa', 'routes/mpa.tsx'),
-  route('/mpa/detail', 'routes/mpa.detail.tsx'),
+  ...(isSpa
+    ? []
+    : [
+        route('/mpa', 'routes/mpa.tsx'),
+        route('/mpa/detail', 'routes/mpa.detail.tsx'),
+      ]),
 ] satisfies RouteConfig

--- a/packages/app-react-router/app/routes/mpa.detail.tsx
+++ b/packages/app-react-router/app/routes/mpa.detail.tsx
@@ -1,0 +1,11 @@
+import type { Route } from './+types/mpa.detail'
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url)
+  const id = url.searchParams.get('id')
+  return { id }
+}
+
+export default function MpaDetailPage({ loaderData }: Route.ComponentProps) {
+  return <p id="detail-id">{loaderData.id}</p>
+}

--- a/packages/app-react-router/app/routes/mpa.tsx
+++ b/packages/app-react-router/app/routes/mpa.tsx
@@ -1,0 +1,25 @@
+import { testData } from '../../../testdata/src/ssr'
+import type { Route } from './+types/mpa'
+
+export async function loader() {
+  const data = await testData()
+  return { data }
+}
+
+export default function MpaPage({ loaderData }: Route.ComponentProps) {
+  return (
+    <table>
+      <tbody>
+        {loaderData.data.map((entry) => (
+          <tr key={entry.id}>
+            <td>{entry.id}</td>
+            <td>{entry.name}</td>
+            <td>
+              <a href={`/mpa/detail?id=${entry.id}`}>View →</a>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/packages/app-solid-start/src/routes/mpa/detail.tsx
+++ b/packages/app-solid-start/src/routes/mpa/detail.tsx
@@ -1,0 +1,7 @@
+import { useSearchParams } from '@solidjs/router'
+
+export default function MpaDetailPage() {
+  const [searchParams] = useSearchParams()
+
+  return <p id="detail-id">{searchParams.id}</p>
+}

--- a/packages/app-solid-start/src/routes/mpa/index.tsx
+++ b/packages/app-solid-start/src/routes/mpa/index.tsx
@@ -1,0 +1,34 @@
+import { For } from 'solid-js'
+import { query, createAsync } from '@solidjs/router'
+import { testData } from '../../../../testdata/src/ssr'
+
+const getData = query(async () => {
+  'use server'
+  return await testData()
+}, 'mpa-data')
+
+export const route = {
+  load: () => getData(),
+}
+
+export default function MpaPage() {
+  const data = createAsync(() => getData())
+
+  return (
+    <table>
+      <tbody>
+        <For each={data()}>
+          {(entry) => (
+            <tr>
+              <td>{entry.id}</td>
+              <td>{entry.name}</td>
+              <td>
+                <a href={`/mpa/detail?id=${entry.id}`}>View →</a>
+              </td>
+            </tr>
+          )}
+        </For>
+      </tbody>
+    </table>
+  )
+}

--- a/packages/app-sveltekit/src/routes/mpa/+page.server.ts
+++ b/packages/app-sveltekit/src/routes/mpa/+page.server.ts
@@ -1,0 +1,5 @@
+import { testData } from '../../../../testdata/src/ssr'
+
+export const load = async () => {
+  return { entries: await testData() }
+}

--- a/packages/app-sveltekit/src/routes/mpa/+page.svelte
+++ b/packages/app-sveltekit/src/routes/mpa/+page.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  let { data } = $props()
+</script>
+
+<table>
+  <tbody>
+    {#each data.entries as entry (entry.id)}
+      <tr>
+        <td>{entry.id}</td>
+        <td>{entry.name}</td>
+        <td>
+          <a href="/mpa/detail?id={entry.id}" data-sveltekit-reload>View →</a>
+        </td>
+      </tr>
+    {/each}
+  </tbody>
+</table>

--- a/packages/app-sveltekit/src/routes/mpa/+page.ts
+++ b/packages/app-sveltekit/src/routes/mpa/+page.ts
@@ -1,0 +1,1 @@
+export const csr = false

--- a/packages/app-sveltekit/src/routes/mpa/detail/+page.server.ts
+++ b/packages/app-sveltekit/src/routes/mpa/detail/+page.server.ts
@@ -1,0 +1,6 @@
+import type { PageServerLoad } from './$types'
+
+export const load: PageServerLoad = ({ url }) => {
+  const id = url.searchParams.get('id')
+  return { id }
+}

--- a/packages/app-sveltekit/src/routes/mpa/detail/+page.svelte
+++ b/packages/app-sveltekit/src/routes/mpa/detail/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let { data } = $props()
+</script>
+
+<p id="detail-id">{data.id}</p>

--- a/packages/app-sveltekit/src/routes/mpa/detail/+page.ts
+++ b/packages/app-sveltekit/src/routes/mpa/detail/+page.ts
@@ -1,0 +1,1 @@
+export const csr = false

--- a/packages/app-tanstack-start-react/src/routeTree.gen.ts
+++ b/packages/app-tanstack-start-react/src/routeTree.gen.ts
@@ -9,20 +9,20 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as MpaRouteImport } from './routes/mpa'
 import { Route as SpaRouteImport } from './routes/spa'
+import { Route as MpaRouteImport } from './routes/mpa'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as MpaDetailRouteImport } from './routes/mpa_.detail'
 import { Route as SpaDetailRouteImport } from './routes/spa_.detail'
+import { Route as MpaDetailRouteImport } from './routes/mpa_.detail'
 
-const MpaRoute = MpaRouteImport.update({
-  id: '/mpa',
-  path: '/mpa',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const SpaRoute = SpaRouteImport.update({
   id: '/spa',
   path: '/spa',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MpaRoute = MpaRouteImport.update({
+  id: '/mpa',
+  path: '/mpa',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -30,14 +30,14 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const MpaDetailRoute = MpaDetailRouteImport.update({
-  id: '/mpa_/detail',
-  path: '/mpa/detail',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const SpaDetailRoute = SpaDetailRouteImport.update({
   id: '/spa_/detail',
   path: '/spa/detail',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MpaDetailRoute = MpaDetailRouteImport.update({
+  id: '/mpa_/detail',
+  path: '/mpa/detail',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -81,18 +81,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/mpa': {
-      id: '/mpa'
-      path: '/mpa'
-      fullPath: '/mpa'
-      preLoaderRoute: typeof MpaRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/spa': {
       id: '/spa'
       path: '/spa'
       fullPath: '/spa'
       preLoaderRoute: typeof SpaRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mpa': {
+      id: '/mpa'
+      path: '/mpa'
+      fullPath: '/mpa'
+      preLoaderRoute: typeof MpaRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -102,18 +102,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/mpa_/detail': {
-      id: '/mpa_/detail'
-      path: '/mpa/detail'
-      fullPath: '/mpa/detail'
-      preLoaderRoute: typeof MpaDetailRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/spa_/detail': {
       id: '/spa_/detail'
       path: '/spa/detail'
       fullPath: '/spa/detail'
       preLoaderRoute: typeof SpaDetailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mpa_/detail': {
+      id: '/mpa_/detail'
+      path: '/mpa/detail'
+      fullPath: '/mpa/detail'
+      preLoaderRoute: typeof MpaDetailRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/app-tanstack-start-react/src/routeTree.gen.ts
+++ b/packages/app-tanstack-start-react/src/routeTree.gen.ts
@@ -9,10 +9,17 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as MpaRouteImport } from './routes/mpa'
 import { Route as SpaRouteImport } from './routes/spa'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as MpaDetailRouteImport } from './routes/mpa_.detail'
 import { Route as SpaDetailRouteImport } from './routes/spa_.detail'
 
+const MpaRoute = MpaRouteImport.update({
+  id: '/mpa',
+  path: '/mpa',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SpaRoute = SpaRouteImport.update({
   id: '/spa',
   path: '/spa',
@@ -23,6 +30,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const MpaDetailRoute = MpaDetailRouteImport.update({
+  id: '/mpa_/detail',
+  path: '/mpa/detail',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SpaDetailRoute = SpaDetailRouteImport.update({
   id: '/spa_/detail',
   path: '/spa/detail',
@@ -31,36 +43,51 @@ const SpaDetailRoute = SpaDetailRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/mpa': typeof MpaRoute
   '/spa': typeof SpaRoute
+  '/mpa/detail': typeof MpaDetailRoute
   '/spa/detail': typeof SpaDetailRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/mpa': typeof MpaRoute
   '/spa': typeof SpaRoute
+  '/mpa/detail': typeof MpaDetailRoute
   '/spa/detail': typeof SpaDetailRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/mpa': typeof MpaRoute
   '/spa': typeof SpaRoute
+  '/mpa_/detail': typeof MpaDetailRoute
   '/spa_/detail': typeof SpaDetailRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/spa' | '/spa/detail'
+  fullPaths: '/' | '/mpa' | '/spa' | '/mpa/detail' | '/spa/detail'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/spa' | '/spa/detail'
-  id: '__root__' | '/' | '/spa' | '/spa_/detail'
+  to: '/' | '/mpa' | '/spa' | '/mpa/detail' | '/spa/detail'
+  id: '__root__' | '/' | '/mpa' | '/spa' | '/mpa_/detail' | '/spa_/detail'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  MpaRoute: typeof MpaRoute
   SpaRoute: typeof SpaRoute
+  MpaDetailRoute: typeof MpaDetailRoute
   SpaDetailRoute: typeof SpaDetailRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/mpa': {
+      id: '/mpa'
+      path: '/mpa'
+      fullPath: '/mpa'
+      preLoaderRoute: typeof MpaRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/spa': {
       id: '/spa'
       path: '/spa'
@@ -75,6 +102,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/mpa_/detail': {
+      id: '/mpa_/detail'
+      path: '/mpa/detail'
+      fullPath: '/mpa/detail'
+      preLoaderRoute: typeof MpaDetailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/spa_/detail': {
       id: '/spa_/detail'
       path: '/spa/detail'
@@ -87,7 +121,9 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  MpaRoute: MpaRoute,
   SpaRoute: SpaRoute,
+  MpaDetailRoute: MpaDetailRoute,
   SpaDetailRoute: SpaDetailRoute,
 }
 export const routeTree = rootRouteImport

--- a/packages/app-tanstack-start-react/src/routes/mpa.tsx
+++ b/packages/app-tanstack-start-react/src/routes/mpa.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { testData } from '../../../testdata/src/ssr'
+
+export const Route = createFileRoute('/mpa')({
+  component: MpaPage,
+  loader: async () => await testData(),
+})
+
+function MpaPage() {
+  const data = Route.useLoaderData()
+
+  return (
+    <table>
+      <tbody>
+        {data.map((entry) => (
+          <tr key={entry.id}>
+            <td>{entry.id}</td>
+            <td>{entry.name}</td>
+            <td>
+              <a href={`/mpa/detail?id=${entry.id}`}>View →</a>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/packages/app-tanstack-start-react/src/routes/mpa_.detail.tsx
+++ b/packages/app-tanstack-start-react/src/routes/mpa_.detail.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/mpa_/detail')({
+  loaderDeps: ({ search }) => ({ id: search.id }),
+  loader: ({ deps }) => {
+    return { id: deps.id as string | undefined }
+  },
+  component: MpaDetailPage,
+})
+
+function MpaDetailPage() {
+  const { id } = Route.useLoaderData()
+
+  return <p id="detail-id">{id}</p>
+}

--- a/packages/app-tanstack-start-react/src/routes/mpa_.detail.tsx
+++ b/packages/app-tanstack-start-react/src/routes/mpa_.detail.tsx
@@ -1,15 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/mpa_/detail')({
-  loaderDeps: ({ search }) => ({ id: search.id }),
-  loader: ({ deps }) => {
-    return { id: deps.id as string | undefined }
-  },
+  validateSearch: (search) => ({
+    id: typeof search.id === 'string' ? search.id : undefined,
+  }),
   component: MpaDetailPage,
 })
 
 function MpaDetailPage() {
-  const { id } = Route.useLoaderData()
+  const { id } = Route.useSearch()
 
   return <p id="detail-id">{id}</p>
 }


### PR DESCRIPTION
Set up an MPA route in the app projects for running the same tests as SPA but for MPA as baseline tests.

PR 1/3: This one
PR 2/3: https://github.com/e18e/framework-tracker/pull/185
PR 3/3: https://github.com/e18e/framework-tracker/pull/186

## Checklist

- [ ] If updating UI/UX components ensure you have added screenshots or a gif or video of the changes to the PR description
- [ ] If this is a dependabot PR that bumps a metaframework version, ensure that all package versions in the package match the versions installed by the metaframework version being bumped
- [ ] If this is a dependabot PR that bumps a metaframework version in a `starter-*` package, ensure that the deps, and file content matches the output of the metaframeworks recommended starter/default project
