### PR TITLE
SPA Mode Fails

### DIFF
--- a/packages/app-tanstack-start-react/vite.config.ts
+++ b/packages/app-tanstack-start-react/vite.config.ts
@@ -1,11 +1,14 @@
-import { defineConfig } from 'vite'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
 import { nitro } from 'nitro/vite'
+import { defineConfig } from 'vite'
 
 const isSpa = process.env.BUILD_MODE === 'spa'
 
 export default defineConfig({
+  preview: {
+    host: '127.0.0.1',
+  },
   plugins: [
     ...(isSpa ? [] : [nitro({ preset: 'node-middleware' })]),
     tanstackStart({ spa: { enabled: isSpa } }),


### PR DESCRIPTION
SPA test for TanStack works locally but fails in CI. Seeing if setting the preview works rather than a hack work around first

## Checklist

- [ ] If updating UI/UX components ensure you have added screenshots or a gif or video of the changes to the PR description
- [ ] If this is a dependabot PR that bumps a metaframework version, ensure that all package versions in the package match the versions installed by the metaframework version being bumped
- [ ] If this is a dependabot PR that bumps a metaframework version in a `starter-*` package, ensure that the deps, and file content matches the output of the metaframeworks recommended starter/default project
