### PR TITLE
Ensure SPA tests defaults to SPA

### DIFF
--- a/packages/app-tanstack-start-react/vite.config.ts
+++ b/packages/app-tanstack-start-react/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   },
   plugins: [
     ...(isSpa ? [] : [nitro({ preset: 'node-middleware' })]),
-    tanstackStart({ spa: { enabled: isSpa } }),
+    tanstackStart({ spa: { enabled: isSpa, maskPath: '/spa' } }),
     viteReact(),
   ],
 })


### PR DESCRIPTION
The TanStack test was way slower than all the other SPA tests. Pretty sure it was due to the SPA mode in TanStack and how we are using the routes for different tests. This ensures client and server render together at /spa

## Checklist

- [ ] If updating UI/UX components ensure you have added screenshots or a gif or video of the changes to the PR description
- [ ] If this is a dependabot PR that bumps a metaframework version, ensure that all package versions in the package match the versions installed by the metaframework version being bumped
- [ ] If this is a dependabot PR that bumps a metaframework version in a `starter-*` package, ensure that the deps, and file content matches the output of the metaframeworks recommended starter/default project
