### PR TITLE
Remove manual bridge

### DIFF
--- a/packages/stats-generator/src/serve/react-router.ts
+++ b/packages/stats-generator/src/serve/react-router.ts
@@ -15,45 +15,18 @@ const staticDir = join(appDir, 'build', 'client')
 const buildPath = join(appDir, 'build', 'server', 'index.js')
 const buildUrl = pathToFileURL(buildPath).href
 
-// Resolve react-router from the app's own node_modules, not the stats-generator's.
 const appRequire = createRequire(join(appDir, 'package.json'))
-const rrPath = appRequire.resolve('react-router')
-const { createRequestHandler } = await import(pathToFileURL(rrPath).href)
+const rrNodePath = appRequire.resolve('@react-router/node')
+const { createRequestListener } = await import(pathToFileURL(rrNodePath).href)
 const build = await import(buildUrl)
-const handler = createRequestHandler(build, 'production')
+const handler = createRequestListener({ build, mode: 'production' })
 
-const server = createServer(async (req, res) => {
+const server = createServer((req, res) => {
   const { pathname } = new URL(req.url ?? '/', `http://localhost:${PORT}`)
 
   if (tryServeFile(staticDir, pathname, req, res)) return
 
-  const headers = new Headers(
-    Object.fromEntries(
-      Object.entries(req.headers).map(([k, v]) => [
-        k,
-        Array.isArray(v) ? v.join(', ') : (v ?? ''),
-      ]),
-    ),
-  )
-  const hasBody = req.method !== 'GET' && req.method !== 'HEAD'
-  const webReq = new Request(`http://localhost:${PORT}${req.url ?? '/'}`, {
-    method: req.method,
-    headers,
-    body: hasBody ? req : null,
-    duplex: 'half',
-  })
-
-  const webRes: Response = await handler(webReq)
-
-  res.writeHead(webRes.status, Object.fromEntries(webRes.headers.entries()))
-
-  if (webRes.body) {
-    for await (const chunk of webRes.body) {
-      res.write(chunk)
-    }
-  }
-
-  res.end()
+  handler(req, res)
 }).listen(PORT, () => {
   console.log(`Ready at http://localhost:${PORT}`)
 })


### PR DESCRIPTION
I was manually bridging Node.js HTTP → Web Fetch API on every request for the MPA tests. Replaced the manual bridging with createRequestListener from @react-router/node


## Checklist

- [ ] If updating UI/UX components ensure you have added screenshots or a gif or video of the changes to the PR description
- [ ] If this is a dependabot PR that bumps a metaframework version, ensure that all package versions in the package match the versions installed by the metaframework version being bumped
- [ ] If this is a dependabot PR that bumps a metaframework version in a `starter-*` package, ensure that the deps, and file content matches the output of the metaframeworks recommended starter/default project
