### PR TITLE
docs: use median SSR latency when available

### DIFF
--- a/packages/app-astro/ci-stats.json
+++ b/packages/app-astro/ci-stats.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "5.16.15",
   "ssrOpsPerSec": 385,
   "ssrAvgLatencyMs": 2.628,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 3806,
   "ssrBodySizeKb": 99.86,
   "ssrDuplicationFactor": 1,

--- a/packages/app-astro/stats/5.16.15.json
+++ b/packages/app-astro/stats/5.16.15.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "5.16.15",
   "ssrOpsPerSec": 385,
   "ssrAvgLatencyMs": 2.628,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 3806,
   "ssrBodySizeKb": 99.86,
   "ssrDuplicationFactor": 1,

--- a/packages/app-baseline-html/ci-stats.json
+++ b/packages/app-baseline-html/ci-stats.json
@@ -3,6 +3,7 @@
   "runner": "ubuntu-latest",
   "ssrOpsPerSec": 766,
   "ssrAvgLatencyMs": 1.315,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 7602,
   "ssrBodySizeKb": 96.81,
   "ssrDuplicationFactor": 1

--- a/packages/app-mastro/ci-stats.json
+++ b/packages/app-mastro/ci-stats.json
@@ -3,6 +3,7 @@
   "runner": "ubuntu-latest",
   "ssrOpsPerSec": 339,
   "ssrAvgLatencyMs": 2.983,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 3353,
   "ssrBodySizeKb": 181.95,
   "ssrDuplicationFactor": 1

--- a/packages/app-next-js/ci-stats.json
+++ b/packages/app-next-js/ci-stats.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "16.1.1",
   "ssrOpsPerSec": 125,
   "ssrAvgLatencyMs": 8.117,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 1232,
   "ssrBodySizeKb": 199.11,
   "ssrDuplicationFactor": 2,

--- a/packages/app-next-js/stats/16.1.1.json
+++ b/packages/app-next-js/stats/16.1.1.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "16.1.1",
   "ssrOpsPerSec": 125,
   "ssrAvgLatencyMs": 8.117,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 1232,
   "ssrBodySizeKb": 199.11,
   "ssrDuplicationFactor": 2,

--- a/packages/app-nuxt/ci-stats.json
+++ b/packages/app-nuxt/ci-stats.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "4.2.2",
   "ssrOpsPerSec": 250,
   "ssrAvgLatencyMs": 4.076,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 2454,
   "ssrBodySizeKb": 201.26,
   "ssrDuplicationFactor": 2,

--- a/packages/app-nuxt/stats/4.2.2.json
+++ b/packages/app-nuxt/stats/4.2.2.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "4.2.2",
   "ssrOpsPerSec": 250,
   "ssrAvgLatencyMs": 4.076,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 2454,
   "ssrBodySizeKb": 201.26,
   "ssrDuplicationFactor": 2,

--- a/packages/app-react-router/ci-stats.json
+++ b/packages/app-react-router/ci-stats.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "7.10.1",
   "ssrOpsPerSec": 64,
   "ssrAvgLatencyMs": 15.528,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 644,
   "ssrBodySizeKb": 211.14,
   "ssrDuplicationFactor": 2,

--- a/packages/app-react-router/stats/7.10.1.json
+++ b/packages/app-react-router/stats/7.10.1.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "7.10.1",
   "ssrOpsPerSec": 64,
   "ssrAvgLatencyMs": 15.528,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 644,
   "ssrBodySizeKb": 211.14,
   "ssrDuplicationFactor": 2,

--- a/packages/app-solid-start/ci-stats.json
+++ b/packages/app-solid-start/ci-stats.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "1.2.1",
   "ssrOpsPerSec": 263,
   "ssrAvgLatencyMs": 4.066,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 2460,
   "ssrBodySizeKb": 227.79,
   "ssrDuplicationFactor": 2,

--- a/packages/app-solid-start/stats/1.2.1.json
+++ b/packages/app-solid-start/stats/1.2.1.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "1.2.1",
   "ssrOpsPerSec": 263,
   "ssrAvgLatencyMs": 4.066,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 2460,
   "ssrBodySizeKb": 227.79,
   "ssrDuplicationFactor": 2,

--- a/packages/app-sveltekit/ci-stats.json
+++ b/packages/app-sveltekit/ci-stats.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "2.49.4",
   "ssrOpsPerSec": 276,
   "ssrAvgLatencyMs": 3.725,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 2685,
   "ssrBodySizeKb": 183.55,
   "ssrDuplicationFactor": 2,

--- a/packages/app-sveltekit/stats/2.49.4.json
+++ b/packages/app-sveltekit/stats/2.49.4.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "2.49.4",
   "ssrOpsPerSec": 276,
   "ssrAvgLatencyMs": 3.725,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 2685,
   "ssrBodySizeKb": 183.55,
   "ssrDuplicationFactor": 2,

--- a/packages/app-tanstack-start-react/ci-stats.json
+++ b/packages/app-tanstack-start-react/ci-stats.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "1.145.3",
   "ssrOpsPerSec": 179,
   "ssrAvgLatencyMs": 5.665,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 1766,
   "ssrBodySizeKb": 193.53,
   "ssrDuplicationFactor": 2,

--- a/packages/app-tanstack-start-react/stats/1.145.3.json
+++ b/packages/app-tanstack-start-react/stats/1.145.3.json
@@ -4,6 +4,7 @@
   "frameworkVersion": "1.145.3",
   "ssrOpsPerSec": 179,
   "ssrAvgLatencyMs": 5.665,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 1766,
   "ssrBodySizeKb": 193.53,
   "ssrDuplicationFactor": 2,

--- a/packages/docs/src/components/SSRLatencyChart.astro
+++ b/packages/docs/src/components/SSRLatencyChart.astro
@@ -5,7 +5,7 @@ import ComparisonBarChart from './ComparisonBarChart.astro'
 const data = ssrStats
   .map((f) => ({
     name: f.name,
-    value: f.ssrMedianLatencyMs ?? f.ssrAvgLatencyMs,
+    value: f.ssrMedianLatencyMs,
     focused: f.isFocused,
   }))
   .filter((f) => f?.name != null && Number.isFinite(f.value))

--- a/packages/docs/src/components/SSRLatencyChart.astro
+++ b/packages/docs/src/components/SSRLatencyChart.astro
@@ -3,12 +3,12 @@ import { ssrStats } from '../lib/collections'
 import ComparisonBarChart from './ComparisonBarChart.astro'
 
 const data = ssrStats
-  .filter((f) => f?.name != null && Number.isFinite(f.ssrAvgLatencyMs))
   .map((f) => ({
     name: f.name,
-    value: f.ssrAvgLatencyMs,
+    value: f.ssrMedianLatencyMs ?? f.ssrAvgLatencyMs,
     focused: f.isFocused,
   }))
+  .filter((f) => f?.name != null && Number.isFinite(f.value))
 ---
 
-<ComparisonBarChart title="Avg Latency" data={data} valueFormat="ms" />
+<ComparisonBarChart title="Median Latency" data={data} valueFormat="ms" />

--- a/packages/docs/src/components/SSRStatsTable.astro
+++ b/packages/docs/src/components/SSRStatsTable.astro
@@ -15,7 +15,7 @@ const columns = [
         : null,
   },
   { key: 'ssrOpsPerSec', header: 'Ops/sec' },
-  { key: 'ssrAvgLatencyMs', header: 'Avg Latency' },
+  { key: 'ssrLatencyMs', header: 'Median Latency' },
   { key: 'ssrBodySizeKb', header: 'Body Size' },
   { key: 'ssrDuplicationFactor', header: 'Duplication' },
 ]
@@ -25,7 +25,7 @@ const tableData = ssrStats.map((f) => ({
   package: f.package,
   isFocused: f.package === 'app-baseline-html' ? true : f.isFocused,
   ssrOpsPerSec: f.ssrOpsPerSec?.toLocaleString() ?? '',
-  ssrAvgLatencyMs: `${f.ssrAvgLatencyMs}ms`,
+  ssrLatencyMs: `${f.ssrMedianLatencyMs ?? f.ssrAvgLatencyMs}ms`,
   ssrBodySizeKb: `${f.ssrBodySizeKb}kb`,
   ssrDuplicationFactor: `${f.ssrDuplicationFactor}x`,
 }))

--- a/packages/docs/src/components/SSRStatsTable.astro
+++ b/packages/docs/src/components/SSRStatsTable.astro
@@ -25,7 +25,7 @@ const tableData = ssrStats.map((f) => ({
   package: f.package,
   isFocused: f.package === 'app-baseline-html' ? true : f.isFocused,
   ssrOpsPerSec: f.ssrOpsPerSec?.toLocaleString() ?? '',
-  ssrLatencyMs: `${f.ssrMedianLatencyMs ?? f.ssrAvgLatencyMs}ms`,
+  ssrLatencyMs: `${f.ssrMedianLatencyMs}ms`,
   ssrBodySizeKb: `${f.ssrBodySizeKb}kb`,
   ssrDuplicationFactor: `${f.ssrDuplicationFactor}x`,
 }))

--- a/packages/docs/src/content.config.ts
+++ b/packages/docs/src/content.config.ts
@@ -53,6 +53,7 @@ const runtimeCollection = defineCollection({
     order: z.number(),
     ssrOpsPerSec: z.number(),
     ssrAvgLatencyMs: z.number(),
+    ssrMedianLatencyMs: z.number().optional(),
     ssrSamples: z.number(),
     ssrBodySizeKb: z.number(),
     ssrDuplicationFactor: z.number(),

--- a/packages/docs/src/content.config.ts
+++ b/packages/docs/src/content.config.ts
@@ -53,7 +53,7 @@ const runtimeCollection = defineCollection({
     order: z.number(),
     ssrOpsPerSec: z.number(),
     ssrAvgLatencyMs: z.number(),
-    ssrMedianLatencyMs: z.number().optional(),
+    ssrMedianLatencyMs: z.number(),
     ssrSamples: z.number(),
     ssrBodySizeKb: z.number(),
     ssrDuplicationFactor: z.number(),

--- a/packages/docs/src/content/runtime/app-astro.json
+++ b/packages/docs/src/content/runtime/app-astro.json
@@ -5,6 +5,7 @@
   "type": "ssr-app",
   "ssrOpsPerSec": 385,
   "ssrAvgLatencyMs": 2.628,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 3806,
   "ssrBodySizeKb": 99.86,
   "ssrDuplicationFactor": 1,

--- a/packages/docs/src/content/runtime/app-baseline-html.json
+++ b/packages/docs/src/content/runtime/app-baseline-html.json
@@ -5,6 +5,7 @@
   "isFocused": false,
   "ssrOpsPerSec": 766,
   "ssrAvgLatencyMs": 1.315,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 7602,
   "ssrBodySizeKb": 96.81,
   "ssrDuplicationFactor": 1,

--- a/packages/docs/src/content/runtime/app-mastro.json
+++ b/packages/docs/src/content/runtime/app-mastro.json
@@ -7,6 +7,7 @@
   "runner": "ubuntu-latest",
   "ssrOpsPerSec": 339,
   "ssrAvgLatencyMs": 2.983,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 3353,
   "ssrBodySizeKb": 181.95,
   "ssrDuplicationFactor": 1,

--- a/packages/docs/src/content/runtime/app-next-js.json
+++ b/packages/docs/src/content/runtime/app-next-js.json
@@ -8,6 +8,7 @@
   "frameworkVersion": "16.1.1",
   "ssrOpsPerSec": 125,
   "ssrAvgLatencyMs": 8.117,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 1232,
   "ssrBodySizeKb": 199.11,
   "ssrDuplicationFactor": 2,

--- a/packages/docs/src/content/runtime/app-nuxt.json
+++ b/packages/docs/src/content/runtime/app-nuxt.json
@@ -5,6 +5,7 @@
   "type": "ssr-app",
   "ssrOpsPerSec": 250,
   "ssrAvgLatencyMs": 4.076,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 2454,
   "ssrBodySizeKb": 201.26,
   "ssrDuplicationFactor": 2,

--- a/packages/docs/src/content/runtime/app-react-router.json
+++ b/packages/docs/src/content/runtime/app-react-router.json
@@ -8,6 +8,7 @@
   "frameworkVersion": "7.10.1",
   "ssrOpsPerSec": 64,
   "ssrAvgLatencyMs": 15.528,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 644,
   "ssrBodySizeKb": 211.14,
   "ssrDuplicationFactor": 2,

--- a/packages/docs/src/content/runtime/app-solid-start.json
+++ b/packages/docs/src/content/runtime/app-solid-start.json
@@ -8,6 +8,7 @@
   "frameworkVersion": "1.2.1",
   "ssrOpsPerSec": 263,
   "ssrAvgLatencyMs": 4.066,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 2460,
   "ssrBodySizeKb": 227.79,
   "ssrDuplicationFactor": 2,

--- a/packages/docs/src/content/runtime/app-sveltekit.json
+++ b/packages/docs/src/content/runtime/app-sveltekit.json
@@ -8,6 +8,7 @@
   "frameworkVersion": "2.49.4",
   "ssrOpsPerSec": 276,
   "ssrAvgLatencyMs": 3.725,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 2685,
   "ssrBodySizeKb": 183.55,
   "ssrDuplicationFactor": 2,

--- a/packages/docs/src/content/runtime/app-tanstack-start-react.json
+++ b/packages/docs/src/content/runtime/app-tanstack-start-react.json
@@ -8,6 +8,7 @@
   "frameworkVersion": "1.145.3",
   "ssrOpsPerSec": 179,
   "ssrAvgLatencyMs": 5.665,
+  "ssrMedianLatencyMs": 0,
   "ssrSamples": 1766,
   "ssrBodySizeKb": 193.53,
   "ssrDuplicationFactor": 2,

--- a/packages/docs/src/pages/framework/[slug].astro
+++ b/packages/docs/src/pages/framework/[slug].astro
@@ -137,7 +137,7 @@ const buildData = [
 const ssrColumns = [
   { key: 'name', header: 'Framework', nameCell: true },
   { key: 'ssrOpsPerSec', header: 'Ops/sec' },
-  { key: 'ssrAvgLatencyMs', header: 'Avg Latency' },
+  { key: 'ssrLatencyMs', header: 'Median Latency' },
   { key: 'ssrBodySizeKb', header: 'Body Size' },
   { key: 'ssrDuplicationFactor', header: 'Duplication' },
 ]
@@ -148,7 +148,7 @@ const ssrData = [
         {
           name: baseline.name,
           ssrOpsPerSec: baseline.ssrOpsPerSec?.toLocaleString() ?? '',
-          ssrAvgLatencyMs: `${baseline.ssrAvgLatencyMs}ms`,
+          ssrLatencyMs: `${baseline.ssrMedianLatencyMs ?? baseline.ssrAvgLatencyMs}ms`,
           ssrBodySizeKb: `${baseline.ssrBodySizeKb}kb`,
           ssrDuplicationFactor: `${baseline.ssrDuplicationFactor}x`,
         },
@@ -159,7 +159,7 @@ const ssrData = [
         {
           name: runtime.name,
           ssrOpsPerSec: runtime.ssrOpsPerSec?.toLocaleString() ?? '',
-          ssrAvgLatencyMs: `${runtime.ssrAvgLatencyMs}ms`,
+          ssrLatencyMs: `${runtime.ssrMedianLatencyMs ?? runtime.ssrAvgLatencyMs}ms`,
           ssrBodySizeKb: `${runtime.ssrBodySizeKb}kb`,
           ssrDuplicationFactor: `${runtime.ssrDuplicationFactor}x`,
         },

--- a/packages/docs/src/pages/framework/[slug].astro
+++ b/packages/docs/src/pages/framework/[slug].astro
@@ -148,7 +148,7 @@ const ssrData = [
         {
           name: baseline.name,
           ssrOpsPerSec: baseline.ssrOpsPerSec?.toLocaleString() ?? '',
-          ssrLatencyMs: `${baseline.ssrMedianLatencyMs ?? baseline.ssrAvgLatencyMs}ms`,
+          ssrLatencyMs: `${baseline.ssrMedianLatencyMs}ms`,
           ssrBodySizeKb: `${baseline.ssrBodySizeKb}kb`,
           ssrDuplicationFactor: `${baseline.ssrDuplicationFactor}x`,
         },
@@ -159,7 +159,7 @@ const ssrData = [
         {
           name: runtime.name,
           ssrOpsPerSec: runtime.ssrOpsPerSec?.toLocaleString() ?? '',
-          ssrLatencyMs: `${runtime.ssrMedianLatencyMs ?? runtime.ssrAvgLatencyMs}ms`,
+          ssrLatencyMs: `${runtime.ssrMedianLatencyMs}ms`,
           ssrBodySizeKb: `${runtime.ssrBodySizeKb}kb`,
           ssrDuplicationFactor: `${runtime.ssrDuplicationFactor}x`,
         },

--- a/packages/stats-generator/src/run-ssr-benchmark.ts
+++ b/packages/stats-generator/src/run-ssr-benchmark.ts
@@ -52,6 +52,7 @@ async function main() {
     frameworkVersion,
     ssrOpsPerSec: result.opsPerSec,
     ssrAvgLatencyMs: result.avgLatencyMs,
+    ssrMedianLatencyMs: result.medianLatencyMs,
     ssrSamples: result.samples,
     ssrBodySizeKb: result.bodySizeKb,
     ssrDuplicationFactor: result.duplicationFactor,

--- a/packages/stats-generator/src/save-ci-stats.ts
+++ b/packages/stats-generator/src/save-ci-stats.ts
@@ -181,6 +181,7 @@ async function main() {
           frameworkVersion: ssrStats.frameworkVersion,
           ssrOpsPerSec: ssrStats.ssrOpsPerSec,
           ssrAvgLatencyMs: ssrStats.ssrAvgLatencyMs,
+          ssrMedianLatencyMs: ssrStats.ssrMedianLatencyMs,
           ssrSamples: ssrStats.ssrSamples,
           ssrBodySizeKb: ssrStats.ssrBodySizeKb,
           ssrDuplicationFactor: ssrStats.ssrDuplicationFactor,

--- a/packages/stats-generator/src/schemas.ts
+++ b/packages/stats-generator/src/schemas.ts
@@ -22,7 +22,7 @@ export const BuildStatsSchema = z.object({
 export const SSRStatsSchema = z.object({
   ssrOpsPerSec: z.number().positive(),
   ssrAvgLatencyMs: z.number().nonnegative(),
-  ssrMedianLatencyMs: z.number().nonnegative().optional(),
+  ssrMedianLatencyMs: z.number().nonnegative(),
   ssrSamples: z.number().positive(),
   ssrBodySizeKb: z.number().positive(),
   ssrDuplicationFactor: z.number().nonnegative(),

--- a/packages/stats-generator/src/schemas.ts
+++ b/packages/stats-generator/src/schemas.ts
@@ -22,6 +22,7 @@ export const BuildStatsSchema = z.object({
 export const SSRStatsSchema = z.object({
   ssrOpsPerSec: z.number().positive(),
   ssrAvgLatencyMs: z.number().nonnegative(),
+  ssrMedianLatencyMs: z.number().nonnegative().optional(),
   ssrSamples: z.number().positive(),
   ssrBodySizeKb: z.number().positive(),
   ssrDuplicationFactor: z.number().nonnegative(),

--- a/packages/stats-generator/src/ssr/index.ts
+++ b/packages/stats-generator/src/ssr/index.ts
@@ -105,6 +105,7 @@ export function toSSRStats(result: SSRBenchmarkResult): SSRStats {
     type: 'ssr-app',
     ssrOpsPerSec: result.opsPerSec,
     ssrAvgLatencyMs: result.avgLatencyMs,
+    ssrMedianLatencyMs: result.medianLatencyMs,
     ssrSamples: result.samples,
     ssrBodySizeKb: result.bodySizeKb,
     ssrDuplicationFactor: result.duplicationFactor,

--- a/packages/stats-generator/src/ssr/run-benchmark.ts
+++ b/packages/stats-generator/src/ssr/run-benchmark.ts
@@ -103,6 +103,7 @@ export async function runBenchmark(
       package: config.package,
       opsPerSec: Math.round(task.result.throughput.mean),
       avgLatencyMs: Number(task.result.latency.mean.toFixed(3)),
+      medianLatencyMs: Number(task.result.latency.p50.toFixed(3)),
       samples: task.result.throughput.samplesCount,
       bodySizeKb: Number((length / 1024).toFixed(2)),
       duplicationFactor: Number(duplicationFactor.toFixed(2)),

--- a/packages/stats-generator/src/ssr/types.ts
+++ b/packages/stats-generator/src/ssr/types.ts
@@ -17,6 +17,7 @@ export interface SSRBenchmarkResult {
   package: string
   opsPerSec: number
   avgLatencyMs: number
+  medianLatencyMs: number
   samples: number
   bodySizeKb: number
   duplicationFactor: number
@@ -28,6 +29,7 @@ export interface SSRStats {
   type: 'ssr-app'
   ssrOpsPerSec: number
   ssrAvgLatencyMs: number
+  ssrMedianLatencyMs?: number
   ssrSamples: number
   ssrBodySizeKb: number
   ssrDuplicationFactor: number

--- a/packages/stats-generator/src/ssr/types.ts
+++ b/packages/stats-generator/src/ssr/types.ts
@@ -29,7 +29,7 @@ export interface SSRStats {
   type: 'ssr-app'
   ssrOpsPerSec: number
   ssrAvgLatencyMs: number
-  ssrMedianLatencyMs?: number
+  ssrMedianLatencyMs: number
   ssrSamples: number
   ssrBodySizeKb: number
   ssrDuplicationFactor: number

--- a/packages/stats-generator/src/types.ts
+++ b/packages/stats-generator/src/types.ts
@@ -44,6 +44,7 @@ export interface CIStats {
   // SSR stats
   ssrOpsPerSec?: number
   ssrAvgLatencyMs?: number
+  ssrMedianLatencyMs?: number
   ssrSamples?: number
   ssrBodySizeKb?: number
   ssrDuplicationFactor?: number


### PR DESCRIPTION
﻿## Summary
- record Tinybench p50 SSR latency as `ssrMedianLatencyMs` alongside the existing average latency
- propagate median latency through CI stats merge, schemas, and SSR stats conversion
- display median latency in the SSR chart and tables, with a fallback to existing average latency data until stats artifacts are regenerated

## Testing
- pnpm --filter @framework-tracker/stats-generator type-check
- pnpm --filter @framework-tracker/docs type-check
- pnpm --filter @framework-tracker/docs build
- pnpm exec prettier --check packages/stats-generator/src/ssr/types.ts packages/stats-generator/src/ssr/run-benchmark.ts packages/stats-generator/src/ssr/index.ts packages/stats-generator/src/run-ssr-benchmark.ts packages/stats-generator/src/save-ci-stats.ts packages/stats-generator/src/schemas.ts packages/stats-generator/src/types.ts packages/docs/src/content.config.ts packages/docs/src/components/SSRLatencyChart.astro packages/docs/src/components/SSRStatsTable.astro 'packages/docs/src/pages/framework/[slug].astro'
- git diff --check

Note: `pnpm --filter @framework-tracker/stats-generator validate` currently fails on this checkout because starter package install/build stats JSON files are missing; SSR app stats still validate.

Fixes #215
