### PR TITLE
add: avg install time chart tab

### DIFF
--- a/packages/docs/src/components/BuildSizeCharts.astro
+++ b/packages/docs/src/components/BuildSizeCharts.astro
@@ -1,4 +1,5 @@
 ---
+import InstallTimeAvgChart from './InstallTimeAvgChart.astro'
 import BuildOutputSizeChart from './BuildOutputSizeChart.astro'
 import BuildSizeChart from './BuildSizeChart.astro'
 import BuildSizeProdChart from './BuildSizeProdChart.astro'
@@ -7,12 +8,14 @@ import ChartTabs from './ChartTabs.astro'
 
 <ChartTabs
   sectionId="build"
-  label="Build time graphs"
-  tab1Label="Cold build time"
-  tab2Label="Warm build time"
-  tab3Label="Build output size"
+  label="Build and install time graphs"
+  tab1Label="Avg install time"
+  tab2Label="Cold build time"
+  tab3Label="Warm build time"
+  tab4Label="Build output size"
 >
-  <BuildSizeChart slot="panel-1" />
-  <BuildSizeProdChart slot="panel-2" />
-  <BuildOutputSizeChart slot="panel-3" />
+  <InstallTimeAvgChart slot="panel-1" />
+  <BuildSizeChart slot="panel-2" />
+  <BuildSizeProdChart slot="panel-3" />
+  <BuildOutputSizeChart slot="panel-4" />
 </ChartTabs>

--- a/packages/docs/src/components/ChartTabs.astro
+++ b/packages/docs/src/components/ChartTabs.astro
@@ -8,7 +8,8 @@ interface Props {
   tab4Label?: string
 }
 
-const { sectionId, label, tab1Label, tab2Label, tab3Label, tab4Label } = Astro.props
+const { sectionId, label, tab1Label, tab2Label, tab3Label, tab4Label } =
+  Astro.props
 
 const tab1Id = `${sectionId}-tab-1`
 const tab2Id = `${sectionId}-tab-2`
@@ -56,18 +57,20 @@ const panel4Id = `${sectionId}-panel-4`
         </button>
       )
     }
-    {tab4Label && (
-      <button
-        type="button"
-        role="tab"
-        id={tab4Id}
-        aria-selected="false"
-        aria-controls={panel4Id}
-        class="tab"
-      >
-        {tab4Label}
-      </button>
-    )}
+    {
+      tab4Label && (
+        <button
+          type="button"
+          role="tab"
+          id={tab4Id}
+          aria-selected="false"
+          aria-controls={panel4Id}
+          class="tab"
+        >
+          {tab4Label}
+        </button>
+      )
+    }
   </div>
   <div class="chart-tabpanels">
     <div
@@ -100,17 +103,19 @@ const panel4Id = `${sectionId}-panel-4`
         </div>
       )
     }
-    {tab4Label && (
-      <div
-        role="tabpanel"
-        id={panel4Id}
-        aria-labelledby={tab4Id}
-        class="chart-tabpanel"
-        hidden
-      >
-        <slot name="panel-4" />
-      </div>
-    )}
+    {
+      tab4Label && (
+        <div
+          role="tabpanel"
+          id={panel4Id}
+          aria-labelledby={tab4Id}
+          class="chart-tabpanel"
+          hidden
+        >
+          <slot name="panel-4" />
+        </div>
+      )
+    }
   </div>
 </div>
 

--- a/packages/docs/src/components/ChartTabs.astro
+++ b/packages/docs/src/components/ChartTabs.astro
@@ -5,16 +5,19 @@ interface Props {
   tab1Label: string
   tab2Label: string
   tab3Label?: string
+  tab4Label?: string
 }
 
-const { sectionId, label, tab1Label, tab2Label, tab3Label } = Astro.props
+const { sectionId, label, tab1Label, tab2Label, tab3Label, tab4Label } = Astro.props
 
 const tab1Id = `${sectionId}-tab-1`
 const tab2Id = `${sectionId}-tab-2`
 const tab3Id = `${sectionId}-tab-3`
+const tab4Id = `${sectionId}-tab-4`
 const panel1Id = `${sectionId}-panel-1`
 const panel2Id = `${sectionId}-panel-2`
 const panel3Id = `${sectionId}-panel-3`
+const panel4Id = `${sectionId}-panel-4`
 ---
 
 <div class="chart-tabs-container" data-tab-section={sectionId}>
@@ -53,6 +56,18 @@ const panel3Id = `${sectionId}-panel-3`
         </button>
       )
     }
+    {tab4Label && (
+      <button
+        type="button"
+        role="tab"
+        id={tab4Id}
+        aria-selected="false"
+        aria-controls={panel4Id}
+        class="tab"
+      >
+        {tab4Label}
+      </button>
+    )}
   </div>
   <div class="chart-tabpanels">
     <div
@@ -85,6 +100,17 @@ const panel3Id = `${sectionId}-panel-3`
         </div>
       )
     }
+    {tab4Label && (
+      <div
+        role="tabpanel"
+        id={panel4Id}
+        aria-labelledby={tab4Id}
+        class="chart-tabpanel"
+        hidden
+      >
+        <slot name="panel-4" />
+      </div>
+    )}
   </div>
 </div>
 

--- a/packages/docs/src/components/InstallTimeAvgChart.astro
+++ b/packages/docs/src/components/InstallTimeAvgChart.astro
@@ -6,11 +6,18 @@ const validEntries = starterStats.filter(
   (f) => f?.name != null && Number.isFinite(f.installTime?.avgMs),
 )
 
-const data = validEntries.map((f) => ({
-  name: f.name,
-  value: f.installTime.avgMs / 1000,
-  focused: f.isFocused,
-}))
+const data = validEntries
+  .map((f) => ({
+    name: f.name,
+    value: f.installTime.avgMs / 1000,
+    focused: f.isFocused,
+  }))
+  .sort((a, b) => a.value - b.value || a.name.localeCompare(b.name))
 ---
 
-<ComparisonBarChart title="Avg install time" data={data} valueFormat="s" />
+<ComparisonBarChart
+  title="Avg install time"
+  data={data}
+  valueFormat="s"
+  yAxisLabel="Seconds"
+/>

--- a/packages/docs/src/components/InstallTimeAvgChart.astro
+++ b/packages/docs/src/components/InstallTimeAvgChart.astro
@@ -14,4 +14,3 @@ const data = validEntries.map((f) => ({
 ---
 
 <ComparisonBarChart title="Avg install time" data={data} valueFormat="s" />
-

--- a/packages/docs/src/components/InstallTimeAvgChart.astro
+++ b/packages/docs/src/components/InstallTimeAvgChart.astro
@@ -1,0 +1,17 @@
+---
+import { starterStats } from '../lib/collections'
+import ComparisonBarChart from './ComparisonBarChart.astro'
+
+const validEntries = starterStats.filter(
+  (f) => f?.name != null && Number.isFinite(f.installTime?.avgMs),
+)
+
+const data = validEntries.map((f) => ({
+  name: f.name,
+  value: f.installTime.avgMs / 1000,
+  focused: f.isFocused,
+}))
+---
+
+<ComparisonBarChart title="Avg install time" data={data} valueFormat="s" />
+


### PR DESCRIPTION
added an “Avg install time” tab to the build/install D3 chart comparisons, build times were already there.

<img width="785" height="551" alt="image" src="https://github.com/user-attachments/assets/676b9869-d6f6-480a-b055-2fbad24ba2f5" />

closes: #118 