### PR TITLE
Fixed TanStack Spa Issue

### DIFF
--- a/packages/app-tanstack-start-react/src/router.tsx
+++ b/packages/app-tanstack-start-react/src/router.tsx
@@ -7,6 +7,7 @@ export const getRouter = () => {
     context: {},
     scrollRestoration: true,
     defaultPreloadStaleTime: 0,
+    defaultPendingMinMs: 0,
   })
 
   return router


### PR DESCRIPTION
TanStack SPA tests were much higher than others. TanStack Router has some settings that help with flashing loaders, which are great in a real app but terrible in benchmarking. Turned the other one off.

There might be another issue but this one needs to be turned off first