### PR TITLE
Swapped for NuxtLink

### DIFF
--- a/packages/app-nuxt/app/pages/mpa/index.vue
+++ b/packages/app-nuxt/app/pages/mpa/index.vue
@@ -11,7 +11,7 @@ const { data } = await useAsyncData(() => testData(), { deep: false })
         <td>{{ entry.id }}</td>
         <td>{{ entry.name }}</td>
         <td>
-          <a :href="`/mpa/${entry.id}`">View →</a>
+          <NuxtLink :to="`/mpa/${entry.id}`">View →</NuxtLink>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
As part of the Nuxt review https://github.com/e18e/framework-tracker/issues/196, an issue was found with the MPA test. We should be using the Nuxt Link; however, this means we do not strictly meet our Glossary 

```
Multi-Page Application (MPA)

In an MPA, each navigation triggers a full page load by the browser and the server (or CDN) responds with a complete HTML document, so the browser always receives ready-to-display content. JavaScript is optional and typically used only for progressive enhancement. In-memory state is lost on every navigation. Because content is present in the initial HTML response, MPAs are naturally SEO-friendly.
```

See https://github.com/e18e/framework-tracker/issues/240 for more details, but something needs to change cc @Fuzzyma
