### PR TITLE
Move Away From Full Page Load

### DIFF
--- a/packages/app-next-js/app/mpa/page.tsx
+++ b/packages/app-next-js/app/mpa/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { testData } from '../../../testdata/src/ssr'
 
 export const dynamic = 'force-dynamic'
@@ -13,7 +14,7 @@ export default async function MpaPage() {
             <td>{entry.id}</td>
             <td>{entry.name}</td>
             <td>
-              <a href={`/mpa/${entry.id}`}>View →</a>
+              <Link href={`/mpa/${entry.id}`}>View →</Link>
             </td>
           </tr>
         ))}

--- a/packages/app-react-router/app/routes/mpa.tsx
+++ b/packages/app-react-router/app/routes/mpa.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router'
 import { testData } from '../../../testdata/src/ssr'
 import type { Route } from './+types/mpa'
 
@@ -15,7 +16,7 @@ export default function MpaPage({ loaderData }: Route.ComponentProps) {
             <td>{entry.id}</td>
             <td>{entry.name}</td>
             <td>
-              <a href={`/mpa/${entry.id}`}>View →</a>
+              <Link to={`/mpa/${entry.id}`}>View →</Link>
             </td>
           </tr>
         ))}

--- a/packages/app-solid-start/src/routes/mpa/index.tsx
+++ b/packages/app-solid-start/src/routes/mpa/index.tsx
@@ -1,5 +1,5 @@
 import { For } from 'solid-js'
-import { query, createAsync } from '@solidjs/router'
+import { A, query, createAsync } from '@solidjs/router'
 import { testData } from '../../../../testdata/src/ssr'
 
 const getData = query(async () => {
@@ -23,7 +23,7 @@ export default function MpaPage() {
               <td>{entry.id}</td>
               <td>{entry.name}</td>
               <td>
-                <a href={`/mpa/${entry.id}`}>View →</a>
+                <A href={`/mpa/${entry.id}`}>View →</A>
               </td>
             </tr>
           )}

--- a/packages/app-sveltekit/src/routes/mpa/+page.svelte
+++ b/packages/app-sveltekit/src/routes/mpa/+page.svelte
@@ -9,7 +9,7 @@
         <td>{entry.id}</td>
         <td>{entry.name}</td>
         <td>
-          <a href="/mpa/{entry.id}" data-sveltekit-reload>View →</a>
+          <a href="/mpa/{entry.id}">View →</a>
         </td>
       </tr>
     {/each}

--- a/packages/app-tanstack-start-react/src/routes/mpa.tsx
+++ b/packages/app-tanstack-start-react/src/routes/mpa.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { testData } from '../../../testdata/src/ssr'
 
 export const Route = createFileRoute('/mpa')({
@@ -17,7 +17,9 @@ function MpaPage() {
             <td>{entry.id}</td>
             <td>{entry.name}</td>
             <td>
-              <a href={`/mpa/${entry.id}`}>View →</a>
+              <Link to="/mpa/$id" params={{ id: entry.id }}>
+                View →
+              </Link>
             </td>
           </tr>
         ))}


### PR DESCRIPTION
We are no longer trying to fully stick to an MPA test (which triggers a full document reload), so we want to use the frameworks' links instead. Helps fix #240 

Part of the review process for release:
- #195 
- #197 
- #198 
- #199
- #200