### PR TITLE
Added Load Test Results to Docs

### DIFF
--- a/packages/docs/src/components/ChartTabs.astro
+++ b/packages/docs/src/components/ChartTabs.astro
@@ -127,6 +127,7 @@ const panel4Id = `${sectionId}-panel-4`
 
   .chart-tablist {
     display: flex;
+    flex-wrap: wrap;
     gap: 4px;
     margin: 0;
     padding: 0;

--- a/packages/docs/src/components/SSRLoadP90Charts.astro
+++ b/packages/docs/src/components/SSRLoadP90Charts.astro
@@ -1,0 +1,18 @@
+---
+import ChartTabs from './ChartTabs.astro'
+import SSRLoadWorker25P90LatencyChart from './SSRLoadWorker25P90LatencyChart.astro'
+import SSRLoadWorker50P90LatencyChart from './SSRLoadWorker50P90LatencyChart.astro'
+import SSRLoadWorker100P90LatencyChart from './SSRLoadWorker100P90LatencyChart.astro'
+---
+
+<ChartTabs
+  sectionId="ssr-load-p90"
+  label="SSR load P90 latency graphs"
+  tab1Label="25 Connections"
+  tab2Label="50 Connections"
+  tab3Label="100 Connections"
+>
+  <SSRLoadWorker25P90LatencyChart slot="panel-1" />
+  <SSRLoadWorker50P90LatencyChart slot="panel-2" />
+  <SSRLoadWorker100P90LatencyChart slot="panel-3" />
+</ChartTabs>

--- a/packages/docs/src/components/SSRLoadP99Charts.astro
+++ b/packages/docs/src/components/SSRLoadP99Charts.astro
@@ -1,0 +1,18 @@
+---
+import ChartTabs from './ChartTabs.astro'
+import SSRLoadWorker25P99LatencyChart from './SSRLoadWorker25P99LatencyChart.astro'
+import SSRLoadWorker50P99LatencyChart from './SSRLoadWorker50P99LatencyChart.astro'
+import SSRLoadWorker100P99LatencyChart from './SSRLoadWorker100P99LatencyChart.astro'
+---
+
+<ChartTabs
+  sectionId="ssr-load-p99"
+  label="SSR load P99 latency graphs"
+  tab1Label="25 Connections"
+  tab2Label="50 Connections"
+  tab3Label="100 Connections"
+>
+  <SSRLoadWorker25P99LatencyChart slot="panel-1" />
+  <SSRLoadWorker50P99LatencyChart slot="panel-2" />
+  <SSRLoadWorker100P99LatencyChart slot="panel-3" />
+</ChartTabs>

--- a/packages/docs/src/components/SSRLoadStatsMethodologyNotes.astro
+++ b/packages/docs/src/components/SSRLoadStatsMethodologyNotes.astro
@@ -1,0 +1,31 @@
+---
+import MethodologyNotes from '../components/MethodologyNotes.astro'
+---
+
+<MethodologyNotes>
+  <li>
+    Each framework serves the server-rendered table route over a real local HTTP
+    server
+  </li>
+  <li>
+    The measured route is <code>/server-side-rendered</code>, using the same
+    1000-row UUID table as the SSR request throughput and browser rendering
+    tests
+  </li>
+  <li>
+    Load is applied in staged connection counts, from 1 through 200 concurrent
+    connections, with each stage running for approximately 5 seconds
+  </li>
+  <li>
+    Peak requests/sec is the highest successful stage throughput observed during
+    the staged run
+  </li>
+  <li>
+    P90 and P99 latency are compared at the 25-, 50-, and 100-connection stages
+    for every framework, so latency is measured under the same concurrency
+    pressure
+  </li>
+  <li>
+    Total requests cover the full staged load run, not only the peak stage
+  </li>
+</MethodologyNotes>

--- a/packages/docs/src/components/SSRLoadStatsTable.astro
+++ b/packages/docs/src/components/SSRLoadStatsTable.astro
@@ -1,0 +1,29 @@
+---
+import { ssrLoadStats } from '../lib/collections'
+import { getFrameworkSlug } from '../lib/utils'
+import StatsTable from './StatsTable.astro'
+
+const columns = [
+  {
+    key: 'name',
+    header: 'Framework',
+    nameCell: true,
+    href: (row: Record<string, unknown>) =>
+      row.package !== 'app-baseline-html'
+        ? `/framework/${getFrameworkSlug(row.package as string)}`
+        : null,
+  },
+  { key: 'peakRequestsPerSec', header: 'Peak req/s' },
+  { key: 'peakWorkers', header: 'Peak Connections' },
+  { key: 'worker25P99LatencyMs', header: 'P99 @ 25' },
+  { key: 'worker50P99LatencyMs', header: 'P99 @ 50' },
+  { key: 'worker100P99LatencyMs', header: 'P99 @ 100' },
+  { key: 'totalRequests', header: 'Total Req.' },
+]
+---
+
+<StatsTable
+  label="SSR load tests by framework"
+  columns={columns}
+  data={ssrLoadStats}
+/>

--- a/packages/docs/src/components/SSRLoadWorker100P90LatencyChart.astro
+++ b/packages/docs/src/components/SSRLoadWorker100P90LatencyChart.astro
@@ -1,0 +1,15 @@
+---
+import { chartSSRLoadWorker100P90LatencyData } from '../lib/collections'
+import ComparisonBarChart from './ComparisonBarChart.astro'
+
+const data = [...chartSSRLoadWorker100P90LatencyData].sort(
+  (a, b) => a.value - b.value || a.name.localeCompare(b.name),
+)
+---
+
+<ComparisonBarChart
+  title="P90 Latency at 100 Connections"
+  data={data}
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>

--- a/packages/docs/src/components/SSRLoadWorker100P99LatencyChart.astro
+++ b/packages/docs/src/components/SSRLoadWorker100P99LatencyChart.astro
@@ -1,0 +1,15 @@
+---
+import { chartSSRLoadWorker100P99LatencyData } from '../lib/collections'
+import ComparisonBarChart from './ComparisonBarChart.astro'
+
+const data = [...chartSSRLoadWorker100P99LatencyData].sort(
+  (a, b) => a.value - b.value || a.name.localeCompare(b.name),
+)
+---
+
+<ComparisonBarChart
+  title="P99 Latency at 100 Connections"
+  data={data}
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>

--- a/packages/docs/src/components/SSRLoadWorker25P90LatencyChart.astro
+++ b/packages/docs/src/components/SSRLoadWorker25P90LatencyChart.astro
@@ -1,0 +1,15 @@
+---
+import { chartSSRLoadWorker25P90LatencyData } from '../lib/collections'
+import ComparisonBarChart from './ComparisonBarChart.astro'
+
+const data = [...chartSSRLoadWorker25P90LatencyData].sort(
+  (a, b) => a.value - b.value || a.name.localeCompare(b.name),
+)
+---
+
+<ComparisonBarChart
+  title="P90 Latency at 25 Connections"
+  data={data}
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>

--- a/packages/docs/src/components/SSRLoadWorker25P99LatencyChart.astro
+++ b/packages/docs/src/components/SSRLoadWorker25P99LatencyChart.astro
@@ -1,0 +1,15 @@
+---
+import { chartSSRLoadWorker25P99LatencyData } from '../lib/collections'
+import ComparisonBarChart from './ComparisonBarChart.astro'
+
+const data = [...chartSSRLoadWorker25P99LatencyData].sort(
+  (a, b) => a.value - b.value || a.name.localeCompare(b.name),
+)
+---
+
+<ComparisonBarChart
+  title="P99 Latency at 25 Connections"
+  data={data}
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>

--- a/packages/docs/src/components/SSRLoadWorker50P90LatencyChart.astro
+++ b/packages/docs/src/components/SSRLoadWorker50P90LatencyChart.astro
@@ -1,0 +1,15 @@
+---
+import { chartSSRLoadWorker50P90LatencyData } from '../lib/collections'
+import ComparisonBarChart from './ComparisonBarChart.astro'
+
+const data = [...chartSSRLoadWorker50P90LatencyData].sort(
+  (a, b) => a.value - b.value || a.name.localeCompare(b.name),
+)
+---
+
+<ComparisonBarChart
+  title="P90 Latency at 50 Connections"
+  data={data}
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>

--- a/packages/docs/src/components/SSRLoadWorker50P99LatencyChart.astro
+++ b/packages/docs/src/components/SSRLoadWorker50P99LatencyChart.astro
@@ -1,0 +1,15 @@
+---
+import { chartSSRLoadWorker50P99LatencyData } from '../lib/collections'
+import ComparisonBarChart from './ComparisonBarChart.astro'
+
+const data = [...chartSSRLoadWorker50P99LatencyData].sort(
+  (a, b) => a.value - b.value || a.name.localeCompare(b.name),
+)
+---
+
+<ComparisonBarChart
+  title="P99 Latency at 50 Connections"
+  data={data}
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>

--- a/packages/docs/src/lib/collections.ts
+++ b/packages/docs/src/lib/collections.ts
@@ -12,6 +12,62 @@ export const ssrRequestThroughputStats = runtimeEntries
   .map((entry) => entry.data)
   .sort((a, b) => a.order - b.order)
 
+type RuntimeData = (typeof runtimeEntries)[number]['data']
+
+function getSSRLoadLatencyStage(framework: RuntimeData, workers: number) {
+  return framework.ssrLoadTests?.stages.find(
+    (stage) => stage.workers === workers,
+  )
+}
+
+function getSSRLoadChartData(
+  workers: number,
+  percentile: 'p90LatencyMs' | 'p99LatencyMs',
+) {
+  return runtimeEntries
+    .map((entry) => entry.data)
+    .sort((a, b) => a.order - b.order)
+    .filter((f) => {
+      const stage = getSSRLoadLatencyStage(f, workers)
+      return stage != null && Number.isFinite(stage[percentile])
+    })
+    .map((f) => ({
+      name: f.name,
+      value: getSSRLoadLatencyStage(f, workers)![percentile],
+      focused: f.package === 'app-baseline-html' ? true : f.isFocused,
+    }))
+}
+
+export const ssrLoadStats = runtimeEntries
+  .map((entry) => entry.data)
+  .filter(
+    (framework) =>
+      framework.ssrLoadTests != null &&
+      Number.isFinite(framework.ssrLoadTests.peakRequestsPerSec) &&
+      getSSRLoadLatencyStage(framework, 25) != null &&
+      getSSRLoadLatencyStage(framework, 50) != null &&
+      getSSRLoadLatencyStage(framework, 100) != null,
+  )
+  .sort((a, b) => a.order - b.order)
+  .map((framework) => {
+    const worker25Stage = getSSRLoadLatencyStage(framework, 25)!
+    const worker50Stage = getSSRLoadLatencyStage(framework, 50)!
+    const worker100Stage = getSSRLoadLatencyStage(framework, 100)!
+    return {
+      name: framework.name,
+      package: framework.package,
+      isFocused:
+        framework.package === 'app-baseline-html' ? true : framework.isFocused,
+      peakRequestsPerSec:
+        framework.ssrLoadTests!.peakRequestsPerSec.toLocaleString(),
+      peakWorkers: framework.ssrLoadTests!.peakWorkers.toLocaleString(),
+      worker25P99LatencyMs: `${worker25Stage.p99LatencyMs}ms`,
+      worker50P99LatencyMs: `${worker50Stage.p99LatencyMs}ms`,
+      worker100P99LatencyMs: `${worker100Stage.p99LatencyMs}ms`,
+      totalRequests: framework.ssrLoadTests!.totalRequests.toLocaleString(),
+    }
+  })
+
 export const serverSideRenderedStats = runtimeEntries
   .map((entry) => entry.data)
   .sort((a, b) => a.order - b.order)
@@ -83,6 +139,31 @@ export const chartDuplicateDependencyData = starterStats
     value: f.duplicateDependencies!,
     focused: f.isFocused,
   }))
+
+export const chartSSRLoadWorker25P99LatencyData = getSSRLoadChartData(
+  25,
+  'p99LatencyMs',
+)
+export const chartSSRLoadWorker50P99LatencyData = getSSRLoadChartData(
+  50,
+  'p99LatencyMs',
+)
+export const chartSSRLoadWorker100P99LatencyData = getSSRLoadChartData(
+  100,
+  'p99LatencyMs',
+)
+export const chartSSRLoadWorker25P90LatencyData = getSSRLoadChartData(
+  25,
+  'p90LatencyMs',
+)
+export const chartSSRLoadWorker50P90LatencyData = getSSRLoadChartData(
+  50,
+  'p90LatencyMs',
+)
+export const chartSSRLoadWorker100P90LatencyData = getSSRLoadChartData(
+  100,
+  'p90LatencyMs',
+)
 
 export const chartServerSideRenderedFPData = runtimeEntries
   .map((entry) => entry.data)

--- a/packages/docs/src/pages/framework/[slug].astro
+++ b/packages/docs/src/pages/framework/[slug].astro
@@ -5,10 +5,15 @@ import DevTimeChart from '../../components/DevTimeChart.astro'
 import ServerSideRenderedStatsMethodologyNotes from '../../components/ServerSideRenderedStatsMethodologyNotes.astro'
 import PageHeader from '../../components/PageHeader.astro'
 import ClientSideRenderedStatsMethodologyNotes from '../../components/ClientSideRenderedStatsMethodologyNotes.astro'
+import SSRLoadStatsMethodologyNotes from '../../components/SSRLoadStatsMethodologyNotes.astro'
 import SSRRequestThroughputStatsMethodologyNotes from '../../components/SSRRequestThroughputStatsMethodologyNotes.astro'
 import StatsTable from '../../components/StatsTable.astro'
 import Layout from '../../layouts/Layout.astro'
-import { buildInstallData, depsStats } from '../../lib/collections'
+import {
+  buildInstallData,
+  depsStats,
+  ssrLoadStats,
+} from '../../lib/collections'
 import { getFrameworkSlug } from '../../lib/utils'
 
 export async function getStaticPaths() {
@@ -166,6 +171,23 @@ const ssrRequestThroughputData = [
         },
       ]
     : []),
+]
+
+const ssrLoadColumns = [
+  { key: 'name', header: 'Framework', nameCell: true },
+  { key: 'peakRequestsPerSec', header: 'Peak req/s' },
+  { key: 'peakWorkers', header: 'Peak Connections' },
+  { key: 'worker25P99LatencyMs', header: 'P99 @ 25' },
+  { key: 'worker50P99LatencyMs', header: 'P99 @ 50' },
+  { key: 'worker100P99LatencyMs', header: 'P99 @ 100' },
+  { key: 'totalRequests', header: 'Total Req.' },
+]
+
+const ssrLoadData = [
+  ...ssrLoadStats.filter((entry) => entry.package === 'app-baseline-html'),
+  ...ssrLoadStats.filter(
+    (entry) => runtime && entry.package === runtime.package,
+  ),
 ]
 
 const clientSideRenderedColumns = [
@@ -327,6 +349,13 @@ const serverSideRenderedData = runtime?.serverSideRenderedTests
     runtime && (
       <>
         <h2>Runtime Performance</h2>
+        <h3>SSR Load Tests</h3>
+        <StatsTable
+          label="SSR load tests by framework"
+          columns={ssrLoadColumns}
+          data={ssrLoadData}
+        />
+        <SSRLoadStatsMethodologyNotes />
         <h3>SSR Request Throughput</h3>
         <StatsTable
           label="SSR request throughput by framework"

--- a/packages/docs/src/pages/index.astro
+++ b/packages/docs/src/pages/index.astro
@@ -8,6 +8,7 @@ import Description from '../components/Description.astro'
 import DetailsLink from '../components/DetailsLink.astro'
 import PageHeader from '../components/PageHeader.astro'
 import ClientSideRenderedCharts from '../components/ClientSideRenderedCharts.astro'
+import SSRLoadP99Charts from '../components/SSRLoadP99Charts.astro'
 import SSRRequestThroughputCharts from '../components/SSRRequestThroughputCharts.astro'
 import Layout from '../layouts/Layout.astro'
 import DepotLogo from '../assets/depot-logo-horizontal.svg'
@@ -73,6 +74,12 @@ import DepotLogo from '../assets/depot-logo-horizontal.svg'
     label="Core-JS Polyfills in Dev Time Stats"
   />
   <h2>Runtime Performance</h2>
+  <h3>SSR Load Tests</h3>
+  <SSRLoadP99Charts />
+  <DetailsLink
+    href="/run-time#ssr-load"
+    label="SSR Load Tests in Run Time Stats"
+  />
   <h3>SSR Request Throughput</h3>
   <SSRRequestThroughputCharts />
   <DetailsLink

--- a/packages/docs/src/pages/run-time.astro
+++ b/packages/docs/src/pages/run-time.astro
@@ -6,14 +6,27 @@ import PageHeader from '../components/PageHeader.astro'
 import ClientSideRenderedCharts from '../components/ClientSideRenderedCharts.astro'
 import ClientSideRenderedStatsMethodologyNotes from '../components/ClientSideRenderedStatsMethodologyNotes.astro'
 import ClientSideRenderedStatsTable from '../components/ClientSideRenderedStatsTable.astro'
+import SSRLoadP90Charts from '../components/SSRLoadP90Charts.astro'
+import SSRLoadP99Charts from '../components/SSRLoadP99Charts.astro'
+import SSRLoadStatsMethodologyNotes from '../components/SSRLoadStatsMethodologyNotes.astro'
+import SSRLoadStatsTable from '../components/SSRLoadStatsTable.astro'
 import SSRRequestThroughputStatsMethodologyNotes from '../components/SSRRequestThroughputStatsMethodologyNotes.astro'
+import SSRRequestThroughputCharts from '../components/SSRRequestThroughputCharts.astro'
 import SSRRequestThroughputStatsTable from '../components/SSRRequestThroughputStatsTable.astro'
 import Layout from '../layouts/Layout.astro'
 ---
 
 <Layout>
   <PageHeader showToggle>Run Time Stats</PageHeader>
+  <h2 id="ssr-load">SSR Load Tests</h2>
+  <h3>P99 Latency</h3>
+  <SSRLoadP99Charts />
+  <h3>P90 Latency</h3>
+  <SSRLoadP90Charts />
+  <SSRLoadStatsTable />
+  <SSRLoadStatsMethodologyNotes />
   <h2 id="ssr-request-throughput">SSR Request Throughput</h2>
+  <SSRRequestThroughputCharts />
   <SSRRequestThroughputStatsTable />
   <SSRRequestThroughputStatsMethodologyNotes />
   <h2 id="client-side-rendered-performance">


### PR DESCRIPTION
Added the load test results. There is way more than this to compare in the results, but it's a start.

The main page has a high-level overview of latency at different connection amounts. Details page breaks down P99, P90 extra at different connections. Then have a table with the total number of requests extra.

<img width="1796" height="1152" alt="Screen Recording 2026-06-24 at 9 40 06 pm" src="https://github.com/user-attachments/assets/d99d97b5-3d9d-49c8-8126-e4377daf8ab9" />
