### PR TITLE
Fixes for Astro

### DIFF
--- a/packages/app-astro/package.json
+++ b/packages/app-astro/package.json
@@ -21,6 +21,8 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/app-astro/pnpm-lock.yaml
+++ b/packages/app-astro/pnpm-lock.yaml
@@ -27,6 +27,12 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.6
         version: 0.9.6(prettier@3.8.1)(typescript@5.9.3)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/packages/stats-generator/src/serve/common.ts
+++ b/packages/stats-generator/src/serve/common.ts
@@ -1,5 +1,5 @@
 import { createReadStream, statSync } from 'node:fs'
-import { join, extname, resolve } from 'node:path'
+import { join, extname, isAbsolute, relative, resolve } from 'node:path'
 import type { IncomingMessage, ServerResponse, Server } from 'node:http'
 
 export const MIME: Record<string, string> = {
@@ -26,7 +26,7 @@ export function parseAppDir(): string {
     console.error(`Usage: node ${process.argv[1]} <app-dir>`)
     process.exit(1)
   }
-  return appDir
+  return resolve(appDir)
 }
 
 export function tryServeFile(
@@ -42,10 +42,14 @@ export function tryServeFile(
     return false
   }
 
-  const abs = resolve(join(staticDir, decoded))
+  const root = resolve(staticDir)
+  const abs = resolve(join(root, decoded))
 
   // Ensure resolved path stays within staticDir
-  if (abs !== staticDir && !abs.startsWith(staticDir + '/')) return false
+  const relativePath = relative(root, abs)
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    return false
+  }
 
   try {
     const stat = statSync(abs)


### PR DESCRIPTION
- Added React types for Astro as it uses them for its client-side rendering
- Fixed up the scripts a little so client assets don't return 404 when running tests manually 

Part of #194