### PR TITLE
Made Astro Client Side Test Fairer

### DIFF
--- a/packages/app-astro/src/pages/client-side-rendered.astro
+++ b/packages/app-astro/src/pages/client-side-rendered.astro
@@ -1,5 +1,4 @@
 ---
-import { ClientRouter } from 'astro:transitions'
 import ClientSideRenderedPage from '../components/ClientSideRenderedPage'
 ---
 
@@ -8,7 +7,6 @@ import ClientSideRenderedPage from '../components/ClientSideRenderedPage'
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <title>Astro Client Side Rendered Benchmark</title>
-    <ClientRouter />
   </head>
   <body>
     <ClientSideRenderedPage client:only="react" />

--- a/packages/docs/src/components/ClientSideRenderedStatsMethodologyNotes.astro
+++ b/packages/docs/src/components/ClientSideRenderedStatsMethodologyNotes.astro
@@ -26,4 +26,13 @@ import MethodologyNotes from '../components/MethodologyNotes.astro'
     > in its config. All other frameworks (Nuxt, SvelteKit, SolidStart, Astro) disable
     SSR per-route without a separate build.
   </li>
+  <li>
+    Astro uses React for its client-side rendered test: the benchmark table and
+    detail components are React islands rendered with <code
+      >client:only="react"</code
+    >, which prevents Astro from server-rendering those components and lets them
+    render only in the browser. Astro's <code>ClientRouter</code> is not used for
+    this CSR test because it enables client-side transitions and soft navigation behavior
+    rather than client-only rendering.
+  </li>
 </MethodologyNotes>


### PR DESCRIPTION
- Updated Astro Client Side Methodology description
- Remove ClientSide Router as it's not needed for client-side and just ops in view transitions. In most frameworks, you have to opt in for view transitions, so it's not fair to add it for Astro.


@dreyfus92 Please add a better description if I did a shit job above lol

Another fix for #194 

Might be able to close the Astro check now