### PR TITLE
Remove E18E Blog From Site

### DIFF
--- a/packages/docs/src/components/Navbar.astro
+++ b/packages/docs/src/components/Navbar.astro
@@ -26,7 +26,6 @@ const pathname = Astro.url.pathname
           >Glossary</a
         >
         <a href="https://e18e.dev" class="nav-link">e18e.dev</a>
-        <a href="https://e18e.dev/blog" class="nav-link">Blog</a>
       </nav>
 
       <button
@@ -193,7 +192,6 @@ const pathname = Astro.url.pathname
       >Run Time</a
     >
     <a href="https://e18e.dev" class="mobile-nav-link">e18e.dev</a>
-    <a href="https://e18e.dev/blog" class="mobile-nav-link">Blog</a>
   </div>
 </header>
 


### PR DESCRIPTION
Getting the site ready to move to a Doc theme (so the only CSS and styling we need to maintain is the graphs lol). To do this, I need to clean up a little. First steps, let's clean up the nav. We already link to the E18E website blog link is a little to much