### PR TITLE
Starlight P1: Remove D3

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,12 +13,10 @@
   },
   "dependencies": {
     "astro": "^7.0.6",
-    "chart.js": "^4.5.1",
-    "d3": "^7.9.0"
+    "chart.js": "^4.5.1"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
-    "@types/d3": "^7.4.3",
     "eslint-plugin-astro": "^2.1.1"
   }
 }

--- a/packages/docs/src/components/DevTimeChart.astro
+++ b/packages/docs/src/components/DevTimeChart.astro
@@ -20,105 +20,52 @@ const chartData = JSON.stringify([
 ])
 ---
 
-<div class="chart-container">
-  <div class="chart-wrapper" data-timings={chartData}>
-    <svg class="dev-time-chart"></svg>
+<div class="dev-time-chart-container">
+  <div class="dev-time-chart-wrapper" data-timings={chartData}>
+    <canvas
+      aria-label="Dev time performance: Install, Cold Build, and Warm Build times in seconds"
+      role="img"
+    >
+      Dev time performance chart showing minimum, average, and maximum duration
+      for pnpm install, cold build, and warm build.
+    </canvas>
   </div>
-  <div class="chart-tooltip"></div>
 </div>
 
 <style>
-  .chart-container {
+  .dev-time-chart-container {
     position: relative;
     width: 100%;
     margin-top: 1.5em;
     margin-bottom: 2em;
   }
 
-  .chart-wrapper {
+  .dev-time-chart-wrapper {
+    position: relative;
     width: 100%;
     max-width: 1000px;
+    height: 600px;
     margin: 0 auto;
   }
 
-  .dev-time-chart {
-    width: 100%;
-    height: 600px;
-    display: block;
-  }
-
   @media (max-width: 768px) {
-    .dev-time-chart {
+    .dev-time-chart-wrapper {
       height: 200px;
     }
-  }
-
-  .chart-tooltip {
-    position: absolute;
-    pointer-events: none;
-    background: var(--ft-bg);
-    border: 1px solid var(--ft-border);
-    border-radius: 6px;
-    padding: 8px 12px;
-    font-size: 13px;
-    line-height: 1.5;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    opacity: 0;
-    transition: opacity 0.15s ease;
-    z-index: 100;
-    color: var(--ft-text);
-  }
-
-  .chart-tooltip.visible {
-    opacity: 1;
-  }
-
-  .chart-tooltip .tooltip-title {
-    font-weight: 600;
-    color: var(--ft-text);
-    margin-bottom: 4px;
-  }
-
-  .chart-tooltip .tooltip-values {
-    color: var(--ft-muted);
-  }
-
-  :global(html.dark) .chart-tooltip {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-  }
-
-  /* Axis text styling - uses CSS variables for theme support */
-  .chart-wrapper :global(.x-axis-text) {
-    fill: var(--ft-text);
-    font-size: 13px;
-    font-weight: 500;
-  }
-
-  .chart-wrapper :global(.y-axis-text) {
-    fill: var(--ft-muted);
-    font-size: 12px;
-  }
-
-  .chart-wrapper :global(.y-axis-label) {
-    fill: var(--ft-muted);
-    font-size: 13px;
-  }
-
-  .chart-wrapper :global(.axis-domain) {
-    stroke: var(--ft-border);
-  }
-
-  .chart-wrapper :global(.axis-tick-line) {
-    stroke: var(--ft-border);
-  }
-
-  .chart-wrapper :global(.grid-line) {
-    stroke: var(--ft-chart-grid, var(--ft-border));
   }
 </style>
 
 <script>
-  import * as d3 from 'd3'
+  import {
+    BarController,
+    BarElement,
+    CategoryScale,
+    Chart,
+    Legend,
+    LinearScale,
+    Tooltip,
+  } from 'chart.js'
+  import type { ChartDataset, Plugin } from 'chart.js'
 
   interface ChartDataPoint {
     label: string
@@ -134,359 +81,260 @@ const chartData = JSON.stringify([
     max: number
   }
 
-  function initChart(wrapper: HTMLElement) {
-    const svg = wrapper.querySelector('.dev-time-chart') as SVGSVGElement
-    const tooltip = wrapper.parentElement?.querySelector(
-      '.chart-tooltip',
-    ) as HTMLElement
-    if (!svg || !tooltip) return
+  type DevTimeDataset = ChartDataset<'bar', [number, number][]> & {
+    devTimeData: DataInSeconds[]
+  }
 
+  const CHART_COLOR = '#c0b9dd'
+  const TEXT_COLOR_FALLBACK = '#1f2933'
+  const MUTED_COLOR_FALLBACK = '#697586'
+  const BORDER_COLOR_FALLBACK = '#d9dee7'
+  const MARKER_COLOR_FALLBACK = '#3f3f46'
+  const TICK_STEP_SECONDS = 0.5
+
+  function getCssVar(element: Element, name: string, fallback: string) {
+    return getComputedStyle(element).getPropertyValue(name).trim() || fallback
+  }
+
+  function formatSeconds(value: number) {
+    return `${value.toFixed(2)}s`
+  }
+
+  const rangeMarkersPlugin: Plugin<'bar'> = {
+    id: 'devTimeRangeMarkers',
+    afterDatasetsDraw(chart) {
+      const dataset = chart.data.datasets[0] as DevTimeDataset | undefined
+      const data = dataset?.devTimeData
+      const yScale = chart.scales.y
+      if (!data?.length || !yScale) return
+
+      const meta = chart.getDatasetMeta(0)
+      const { chartArea, ctx } = chart
+      const lineColor = getCssVar(
+        document.documentElement,
+        '--ft-text',
+        MARKER_COLOR_FALLBACK,
+      )
+
+      ctx.save()
+      ctx.strokeStyle = lineColor
+      ctx.lineCap = 'round'
+
+      meta.data.forEach((element, index) => {
+        const point = data[index]
+        if (!point) return
+
+        const { x, width } = element.getProps(['x', 'width'], true) as {
+          x: number
+          width: number
+        }
+        const barWidth = Math.max(8, Number(width) || 0)
+        const boxLeft = x - barWidth / 2
+        const boxRight = x + barWidth / 2
+        const capLeft = x - barWidth / 4
+        const capRight = x + barWidth / 4
+        const minY = yScale.getPixelForValue(point.min)
+        const maxY = yScale.getPixelForValue(point.max)
+        const avgY = yScale.getPixelForValue(point.avg)
+
+        ctx.lineWidth = 1.5
+        ctx.beginPath()
+        ctx.moveTo(x, chartArea.bottom)
+        ctx.lineTo(x, chartArea.top)
+        ctx.moveTo(capLeft, minY)
+        ctx.lineTo(capRight, minY)
+        ctx.moveTo(capLeft, maxY)
+        ctx.lineTo(capRight, maxY)
+        ctx.stroke()
+
+        ctx.lineWidth = 2
+        ctx.beginPath()
+        ctx.moveTo(boxLeft - 5, avgY)
+        ctx.lineTo(boxRight + 5, avgY)
+        ctx.stroke()
+      })
+
+      ctx.restore()
+    },
+  }
+
+  Chart.register(
+    BarController,
+    BarElement,
+    CategoryScale,
+    Legend,
+    LinearScale,
+    Tooltip,
+    rangeMarkersPlugin,
+  )
+
+  const chartCache = new WeakMap<
+    HTMLCanvasElement,
+    Chart<'bar', [number, number][], string>
+  >()
+  const resizeObserverCache = new WeakMap<HTMLElement, ResizeObserver>()
+
+  function getData(wrapper: HTMLElement): DataInSeconds[] | null {
     const dataAttr = wrapper.dataset.timings
-    if (!dataAttr) return
+    if (!dataAttr) return null
 
     let data: ChartDataPoint[]
     try {
       data = JSON.parse(dataAttr) as ChartDataPoint[]
     } catch (e) {
       console.warn('[DevTimeChart] Invalid chart data:', e)
-      return
+      return null
     }
-    const dataInSeconds: DataInSeconds[] = data.map((d) => ({
+
+    return data.map((d) => ({
       label: d.label,
       avg: d.avgMs / 1000,
       min: d.minMs / 1000,
       max: d.maxMs / 1000,
     }))
-
-    // Chart dimensions
-    const margin = { top: 30, right: 30, bottom: 50, left: 60 }
-    const rect = svg.getBoundingClientRect()
-    const width = rect.width || 500
-    const height = rect.height || 300
-    const innerWidth = width - margin.left - margin.right
-    const innerHeight = height - margin.top - margin.bottom
-
-    // Clear any existing content
-    d3.select(svg).selectAll('*').remove()
-
-    // Set viewBox for responsiveness
-    d3.select(svg).attr('viewBox', `0 0 ${width} ${height}`)
-
-    // Accessible labels for screen readers
-    d3.select(svg)
-      .append('title')
-      .text(
-        'Dev time performance: Install, Cold Build, and Warm Build times in seconds',
-      )
-    d3.select(svg)
-      .append('desc')
-      .text(
-        'Box chart showing minimum, average, and maximum duration for pnpm install, cold build, and warm build. See table above for exact values.',
-      )
-
-    // Unique gradient ID to avoid collision when multiple charts exist in DOM
-    const gradientId = `boxGradient-${crypto.randomUUID()}`
-
-    // Create main group
-    const g = d3
-      .select(svg)
-      .append('g')
-      .attr('transform', `translate(${margin.left},${margin.top})`)
-
-    // Define gradient
-    const defs = d3.select(svg).append('defs')
-    const gradient = defs
-      .append('linearGradient')
-      .attr('id', gradientId)
-      .attr('x1', '0%')
-      .attr('y1', '0%')
-      .attr('x2', '100%')
-      .attr('y2', '0%')
-
-    gradient.append('stop').attr('offset', '0%').attr('stop-color', '#7cb560')
-    gradient.append('stop').attr('offset', '100%').attr('stop-color', '#cf8c3c')
-
-    // Scales
-    const xScale = d3
-      .scaleBand()
-      .domain(dataInSeconds.map((d) => d.label))
-      .range([0, innerWidth])
-      .padding(0.4)
-
-    const maxValue = d3.max(dataInSeconds, (d) => d.max) || 5
-    const minValue = d3.min(dataInSeconds, (d) => d.min) || 0
-
-    // Calculate range and set Y domain to zoom in on data
-    const dataRange = maxValue - minValue
-    const yMin = Math.max(0, minValue - dataRange * 0.5)
-    const yMax = maxValue + dataRange * 0.4
-
-    const yScale = d3.scaleLinear().domain([yMin, yMax]).range([innerHeight, 0])
-
-    // Tick values at 0.5s increments
-    const tickStep = 0.5
-    const startTick = Math.floor(yMin / tickStep) * tickStep
-    const yTickValues = d3.range(startTick, yMax + tickStep / 2, tickStep)
-
-    // X axis
-    g.append('g')
-      .attr('transform', `translate(0,${innerHeight})`)
-      .call(d3.axisBottom(xScale).tickSize(0))
-      .call((sel) => sel.select('.domain').attr('class', 'axis-domain'))
-      .call((sel) =>
-        sel.selectAll('text').attr('class', 'x-axis-text').attr('dy', '1em'),
-      )
-
-    // Y axis
-    g.append('g')
-      .call(
-        d3
-          .axisLeft(yScale)
-          .tickValues(yTickValues)
-          .tickFormat((d) => `${d}s`),
-      )
-      .call((sel) => sel.select('.domain').attr('class', 'axis-domain'))
-      .call((sel) =>
-        sel.selectAll('.tick line').attr('class', 'axis-tick-line'),
-      )
-      .call((sel) => sel.selectAll('text').attr('class', 'y-axis-text'))
-
-    // Y axis label
-    g.append('text')
-      .attr('class', 'y-axis-label')
-      .attr('transform', 'rotate(-90)')
-      .attr('y', -45)
-      .attr('x', -innerHeight / 2)
-      .attr('text-anchor', 'middle')
-      .text('Seconds')
-
-    // Grid lines
-    g.append('g')
-      .attr('class', 'grid')
-      .call(
-        d3
-          .axisLeft(yScale)
-          .tickValues(yTickValues)
-          .tickSize(-innerWidth)
-          .tickFormat(() => ''),
-      )
-      .call((sel) => sel.select('.domain').remove())
-      .call((sel) => sel.selectAll('.tick line').attr('class', 'grid-line'))
-
-    // Create box groups
-    const boxWidth = xScale.bandwidth()
-
-    const boxes = g
-      .selectAll('.box-group')
-      .data(dataInSeconds)
-      .enter()
-      .append('g')
-      .attr('class', 'box-group')
-      .attr('transform', (d) => `translate(${xScale(d.label)},0)`)
-
-    // Box rectangles (min to max range) - start with 0 height for animation
-    boxes
-      .append('rect')
-      .attr('class', 'box')
-      .attr('x', 0)
-      .attr('y', (d) => yScale(d.avg))
-      .attr('width', boxWidth)
-      .attr('height', 0)
-      .attr('fill', `url(#${gradientId})`)
-      .attr('stroke', 'rgba(0, 0, 0, 0.3)')
-      .attr('stroke-width', 1)
-      .attr('opacity', 0.9)
-      .attr('rx', 4)
-      .attr('ry', 4)
-      .style('cursor', 'pointer')
-
-    const lineColor = '#666666'
-
-    // Average line
-    boxes
-      .append('line')
-      .attr('class', 'avg-line')
-      .attr('x1', -5)
-      .attr('x2', boxWidth + 5)
-      .attr('y1', (d) => yScale(d.avg))
-      .attr('y2', (d) => yScale(d.avg))
-      .attr('stroke', lineColor)
-      .attr('stroke-width', 2)
-      .attr('opacity', 0)
-
-    // Center spine - vertical line through the middle, spans full chart height
-    boxes
-      .append('line')
-      .attr('class', 'center-spine')
-      .attr('x1', boxWidth / 2)
-      .attr('x2', boxWidth / 2)
-      .attr('y1', innerHeight)
-      .attr('y2', 0)
-      .attr('stroke', lineColor)
-      .attr('stroke-width', 1.5)
-      .attr('opacity', 0)
-
-    // Min whisker
-    boxes
-      .append('line')
-      .attr('class', 'min-whisker')
-      .attr('x1', boxWidth / 2)
-      .attr('x2', boxWidth / 2)
-      .attr('y1', (d) => yScale(d.min))
-      .attr('y2', (d) => yScale(d.min))
-      .attr('stroke', lineColor)
-      .attr('stroke-width', 1.5)
-      .attr('opacity', 0)
-
-    // Max whisker
-    boxes
-      .append('line')
-      .attr('class', 'max-whisker')
-      .attr('x1', boxWidth / 2)
-      .attr('x2', boxWidth / 2)
-      .attr('y1', (d) => yScale(d.max))
-      .attr('y2', (d) => yScale(d.max))
-      .attr('stroke', lineColor)
-      .attr('stroke-width', 1.5)
-      .attr('opacity', 0)
-
-    // Min cap
-    boxes
-      .append('line')
-      .attr('class', 'min-cap')
-      .attr('x1', boxWidth / 4)
-      .attr('x2', (boxWidth * 3) / 4)
-      .attr('y1', (d) => yScale(d.min))
-      .attr('y2', (d) => yScale(d.min))
-      .attr('stroke', lineColor)
-      .attr('stroke-width', 1.5)
-      .attr('opacity', 0)
-
-    // Max cap
-    boxes
-      .append('line')
-      .attr('class', 'max-cap')
-      .attr('x1', boxWidth / 4)
-      .attr('x2', (boxWidth * 3) / 4)
-      .attr('y1', (d) => yScale(d.max))
-      .attr('y2', (d) => yScale(d.max))
-      .attr('stroke', lineColor)
-      .attr('stroke-width', 1.5)
-      .attr('opacity', 0)
-
-    // Hover interactions
-    boxes
-      .on('mouseenter', function (_event: MouseEvent, d: DataInSeconds) {
-        d3.select(this).select('.box').attr('opacity', 1)
-
-        tooltip.innerHTML = `
-          <div class="tooltip-title">${d.label}</div>
-          <div class="tooltip-values">
-            <span>Min: ${d.min.toFixed(2)}s</span><br>
-            <span>Avg: ${d.avg.toFixed(2)}s</span><br>
-            <span>Max: ${d.max.toFixed(2)}s</span>
-          </div>
-        `
-        tooltip.classList.add('visible')
-      })
-      .on('mousemove', function (event: MouseEvent) {
-        const containerRect = wrapper.parentElement?.getBoundingClientRect()
-        if (!containerRect) return
-
-        const x = event.clientX - containerRect.left + 15
-        const y = event.clientY - containerRect.top - 10
-
-        tooltip.style.left = `${x}px`
-        tooltip.style.top = `${y}px`
-      })
-      .on('mouseleave', function () {
-        d3.select(this).select('.box').attr('opacity', 0.9)
-        tooltip.classList.remove('visible')
-      })
-
-    // Animation function
-    function animateIn() {
-      boxes
-        .selectAll('.box')
-        .transition()
-        .duration(600)
-        .ease(d3.easeCubicOut)
-        .attr('y', (d) => yScale((d as DataInSeconds).max))
-        .attr(
-          'height',
-          (d) =>
-            yScale((d as DataInSeconds).min) - yScale((d as DataInSeconds).max),
-        )
-
-      boxes
-        .selectAll('.avg-line')
-        .transition()
-        .delay(400)
-        .duration(300)
-        .attr('opacity', 1)
-
-      boxes
-        .selectAll('.center-spine')
-        .transition()
-        .delay(400)
-        .duration(300)
-        .attr('opacity', 1)
-
-      boxes
-        .selectAll('.min-whisker, .max-whisker')
-        .transition()
-        .delay(300)
-        .duration(400)
-        .attr('y1', function () {
-          const parent = (this as SVGLineElement).parentElement
-          const d = d3.select(parent).datum() as DataInSeconds
-          const isMin = (this as SVGLineElement).classList.contains(
-            'min-whisker',
-          )
-          return yScale(isMin ? d.min : d.max)
-        })
-        .attr('y2', function () {
-          const parent = (this as SVGLineElement).parentElement
-          const d = d3.select(parent).datum() as DataInSeconds
-          const isMin = (this as SVGLineElement).classList.contains(
-            'min-whisker',
-          )
-          return yScale(isMin ? d.min : d.max)
-        })
-        .attr('opacity', 1)
-
-      boxes
-        .selectAll('.min-cap, .max-cap')
-        .transition()
-        .delay(500)
-        .duration(300)
-        .attr('opacity', 1)
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            animateIn()
-            observer.disconnect()
-          }
-        })
-      },
-      { threshold: 1 },
-    )
-
-    observer.observe(svg)
   }
 
-  function init() {
-    document.querySelectorAll('.chart-wrapper').forEach((el) => {
-      initChart(el as HTMLElement)
+  function initChart(wrapper: HTMLElement) {
+    if (wrapper.offsetParent === null) return
+
+    const canvas = wrapper.querySelector('canvas')
+    if (!canvas) return
+
+    const data = getData(wrapper)
+    if (!data?.length) return
+
+    const maxValue = Math.max(...data.map((d) => d.max)) || 5
+    const minValue = Math.min(...data.map((d) => d.min)) || 0
+    const dataRange = Math.max(maxValue - minValue, TICK_STEP_SECONDS)
+    const yMin = Math.max(0, minValue - dataRange * 0.5)
+    const yMax = maxValue + dataRange * 0.4
+    const yAxisMin = Math.floor(yMin / TICK_STEP_SECONDS) * TICK_STEP_SECONDS
+    const yAxisMax = Math.ceil(yMax / TICK_STEP_SECONDS) * TICK_STEP_SECONDS
+    const root = document.documentElement
+    const textColor = getCssVar(root, '--ft-text', TEXT_COLOR_FALLBACK)
+    const mutedColor = getCssVar(root, '--ft-muted', MUTED_COLOR_FALLBACK)
+    const borderColor = getCssVar(root, '--ft-border', BORDER_COLOR_FALLBACK)
+    const gridColor = getCssVar(root, '--ft-chart-grid', borderColor)
+
+    chartCache.get(canvas)?.destroy()
+
+    const dataset: DevTimeDataset = {
+      label: 'Duration range',
+      data: data.map((d) => [d.min, d.max]),
+      devTimeData: data,
+      backgroundColor: CHART_COLOR,
+      borderColor: 'rgba(0, 0, 0, 0.3)',
+      borderRadius: 4,
+      borderSkipped: false,
+      borderWidth: 1,
+      categoryPercentage: 0.6,
+      hoverBackgroundColor: CHART_COLOR,
+    }
+
+    const chart = new Chart<'bar', [number, number][], string>(canvas, {
+      type: 'bar',
+      data: {
+        labels: data.map((d) => d.label),
+        datasets: [dataset],
+      },
+      options: {
+        animation: false,
+        maintainAspectRatio: false,
+        responsive: true,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label: (context) => {
+                const point = data[context.dataIndex]
+                if (!point) return ''
+
+                return [
+                  `Min: ${formatSeconds(point.min)}`,
+                  `Avg: ${formatSeconds(point.avg)}`,
+                  `Max: ${formatSeconds(point.max)}`,
+                ]
+              },
+            },
+          },
+        },
+        scales: {
+          x: {
+            grid: { display: false },
+            ticks: {
+              color: textColor,
+              font: { size: 13, weight: 500 },
+            },
+          },
+          y: {
+            max: yAxisMax,
+            min: yAxisMin,
+            border: { color: gridColor },
+            grid: { color: gridColor },
+            title: {
+              color: mutedColor,
+              display: true,
+              font: { size: 13 },
+              text: 'Seconds',
+            },
+            ticks: {
+              color: mutedColor,
+              font: { size: 12 },
+              stepSize: TICK_STEP_SECONDS,
+              callback: (value) => `${Number(value)}s`,
+            },
+          },
+        },
+      },
+    })
+
+    chartCache.set(canvas, chart)
+
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserverCache.get(wrapper)?.disconnect()
+      const ro = new ResizeObserver(() => chart.resize())
+      ro.observe(wrapper)
+      resizeObserverCache.set(wrapper, ro)
+    }
+  }
+
+  function initCharts(root: ParentNode = document) {
+    root
+      .querySelectorAll<HTMLElement>('.dev-time-chart-wrapper')
+      .forEach(initChart)
+  }
+
+  function scheduleInit(root?: ParentNode) {
+    requestAnimationFrame(() => initCharts(root))
+  }
+
+  function observeThemeClassChanges() {
+    if (typeof MutationObserver === 'undefined') return
+
+    let lastClassName = document.documentElement.className
+    const observer = new MutationObserver(() => {
+      const nextClassName = document.documentElement.className
+      if (nextClassName === lastClassName) return
+
+      lastClassName = nextClassName
+      scheduleInit()
+    })
+
+    observer.observe(document.documentElement, {
+      attributeFilter: ['class'],
+      attributes: true,
     })
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init)
+    document.addEventListener('DOMContentLoaded', () => initCharts())
   } else {
-    init()
+    initCharts()
   }
+
+  observeThemeClassChanges()
+  document.addEventListener('chart-tabpanel-active', (event) => {
+    const panel = (event as CustomEvent<{ panel?: ParentNode }>).detail?.panel
+    if (panel) scheduleInit(panel)
+  })
 </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,16 +48,10 @@ importers:
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
-      d3:
-        specifier: ^7.9.0
-        version: 7.9.0
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.9
         version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.9.4)(typescript@6.0.3)
-      '@types/d3':
-        specifier: ^7.4.3
-        version: 7.4.3
       eslint-plugin-astro:
         specifier: ^2.1.1
         version: 2.1.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)
@@ -174,9 +168,6 @@ packages:
   '@astrojs/compiler-rs@0.3.0':
     resolution: {integrity: sha512-J2qEVHtIDjEM9TxwmwuebOGmZNwhKu/dR7P7qBpnJKGmBBX0vdweQ/4cEXhj8fBbWVUB5V12xWChri3CgKNULQ==}
     engines: {node: '>=22.12.0'}
-
-  '@astrojs/compiler@2.13.0':
-    resolution: {integrity: sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==}
 
   '@astrojs/compiler@2.13.1':
     resolution: {integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==}
@@ -1156,99 +1147,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/d3-array@3.2.2':
-    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
-
-  '@types/d3-axis@3.0.6':
-    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
-
-  '@types/d3-brush@3.0.6':
-    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
-
-  '@types/d3-chord@3.0.6':
-    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
-
-  '@types/d3-color@3.1.3':
-    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
-
-  '@types/d3-contour@3.0.6':
-    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
-
-  '@types/d3-delaunay@6.0.4':
-    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
-
-  '@types/d3-dispatch@3.0.7':
-    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
-
-  '@types/d3-drag@3.0.7':
-    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
-
-  '@types/d3-dsv@3.0.7':
-    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
-
-  '@types/d3-ease@3.0.2':
-    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
-
-  '@types/d3-fetch@3.0.7':
-    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
-
-  '@types/d3-force@3.0.10':
-    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
-
-  '@types/d3-format@3.0.4':
-    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
-
-  '@types/d3-geo@3.1.0':
-    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
-
-  '@types/d3-hierarchy@3.1.7':
-    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
-
-  '@types/d3-interpolate@3.0.4':
-    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
-
-  '@types/d3-path@3.1.1':
-    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
-
-  '@types/d3-polygon@3.0.2':
-    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
-
-  '@types/d3-quadtree@3.0.6':
-    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
-
-  '@types/d3-random@3.0.3':
-    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
-
-  '@types/d3-scale-chromatic@3.1.0':
-    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
-
-  '@types/d3-scale@4.0.9':
-    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
-
-  '@types/d3-selection@3.0.11':
-    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
-
-  '@types/d3-shape@3.1.8':
-    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
-
-  '@types/d3-time-format@4.0.3':
-    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
-
-  '@types/d3-time@3.0.4':
-    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
-
-  '@types/d3-timer@3.0.2':
-    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
-
-  '@types/d3-transition@3.0.9':
-    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
-
-  '@types/d3-zoom@3.0.8':
-    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
-
-  '@types/d3@7.4.3':
-    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
-
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -1257,9 +1155,6 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
-
-  '@types/geojson@7946.0.16':
-    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -1632,10 +1527,6 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
-  commander@7.2.0:
-    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
-    engines: {node: '>= 10'}
-
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
@@ -1691,133 +1582,6 @@ packages:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
-  d3-array@3.2.4:
-    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
-    engines: {node: '>=12'}
-
-  d3-axis@3.0.0:
-    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
-    engines: {node: '>=12'}
-
-  d3-brush@3.0.0:
-    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
-    engines: {node: '>=12'}
-
-  d3-chord@3.0.1:
-    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
-    engines: {node: '>=12'}
-
-  d3-color@3.1.0:
-    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
-    engines: {node: '>=12'}
-
-  d3-contour@4.0.2:
-    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
-    engines: {node: '>=12'}
-
-  d3-delaunay@6.0.4:
-    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
-    engines: {node: '>=12'}
-
-  d3-dispatch@3.0.1:
-    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
-    engines: {node: '>=12'}
-
-  d3-drag@3.0.0:
-    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
-    engines: {node: '>=12'}
-
-  d3-dsv@3.0.1:
-    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
-    engines: {node: '>=12'}
-    hasBin: true
-
-  d3-ease@3.0.1:
-    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
-    engines: {node: '>=12'}
-
-  d3-fetch@3.0.1:
-    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
-    engines: {node: '>=12'}
-
-  d3-force@3.0.0:
-    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
-    engines: {node: '>=12'}
-
-  d3-format@3.1.2:
-    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
-    engines: {node: '>=12'}
-
-  d3-geo@3.1.1:
-    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
-    engines: {node: '>=12'}
-
-  d3-hierarchy@3.1.2:
-    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
-    engines: {node: '>=12'}
-
-  d3-interpolate@3.0.1:
-    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
-    engines: {node: '>=12'}
-
-  d3-path@3.1.0:
-    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
-    engines: {node: '>=12'}
-
-  d3-polygon@3.0.1:
-    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
-    engines: {node: '>=12'}
-
-  d3-quadtree@3.0.1:
-    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
-    engines: {node: '>=12'}
-
-  d3-random@3.0.1:
-    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
-    engines: {node: '>=12'}
-
-  d3-scale-chromatic@3.1.0:
-    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
-    engines: {node: '>=12'}
-
-  d3-scale@4.0.2:
-    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
-    engines: {node: '>=12'}
-
-  d3-selection@3.0.0:
-    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
-    engines: {node: '>=12'}
-
-  d3-shape@3.2.0:
-    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
-    engines: {node: '>=12'}
-
-  d3-time-format@4.1.0:
-    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
-    engines: {node: '>=12'}
-
-  d3-time@3.1.0:
-    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
-    engines: {node: '>=12'}
-
-  d3-timer@3.0.1:
-    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
-    engines: {node: '>=12'}
-
-  d3-transition@3.0.1:
-    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      d3-selection: 2 - 3
-
-  d3-zoom@3.0.0:
-    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
-    engines: {node: '>=12'}
-
-  d3@7.9.0:
-    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
-    engines: {node: '>=12'}
-
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -1843,9 +1607,6 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
-
-  delaunator@5.0.1:
-    resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -2230,10 +1991,6 @@ packages:
   hyperid@3.3.0:
     resolution: {integrity: sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==}
 
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
-
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -2257,10 +2014,6 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  internmap@2.0.3:
-    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
 
   intl-messageformat@10.7.18:
     resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
@@ -2837,25 +2590,16 @@ packages:
     resolution: {integrity: sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==}
     engines: {node: '>=10.0.0'}
 
-  robust-predicates@3.0.2:
-    resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
-
   rolldown@1.1.4:
     resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  rw@1.3.3:
-    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   s.color@0.0.15:
     resolution: {integrity: sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sass-formatter@0.7.9:
     resolution: {integrity: sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==}
@@ -3514,8 +3258,6 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
-
-  '@astrojs/compiler@2.13.0': {}
 
   '@astrojs/compiler@2.13.1': {}
 
@@ -4439,123 +4181,6 @@ snapshots:
     dependencies:
       '@types/node': 26.1.0
 
-  '@types/d3-array@3.2.2': {}
-
-  '@types/d3-axis@3.0.6':
-    dependencies:
-      '@types/d3-selection': 3.0.11
-
-  '@types/d3-brush@3.0.6':
-    dependencies:
-      '@types/d3-selection': 3.0.11
-
-  '@types/d3-chord@3.0.6': {}
-
-  '@types/d3-color@3.1.3': {}
-
-  '@types/d3-contour@3.0.6':
-    dependencies:
-      '@types/d3-array': 3.2.2
-      '@types/geojson': 7946.0.16
-
-  '@types/d3-delaunay@6.0.4': {}
-
-  '@types/d3-dispatch@3.0.7': {}
-
-  '@types/d3-drag@3.0.7':
-    dependencies:
-      '@types/d3-selection': 3.0.11
-
-  '@types/d3-dsv@3.0.7': {}
-
-  '@types/d3-ease@3.0.2': {}
-
-  '@types/d3-fetch@3.0.7':
-    dependencies:
-      '@types/d3-dsv': 3.0.7
-
-  '@types/d3-force@3.0.10': {}
-
-  '@types/d3-format@3.0.4': {}
-
-  '@types/d3-geo@3.1.0':
-    dependencies:
-      '@types/geojson': 7946.0.16
-
-  '@types/d3-hierarchy@3.1.7': {}
-
-  '@types/d3-interpolate@3.0.4':
-    dependencies:
-      '@types/d3-color': 3.1.3
-
-  '@types/d3-path@3.1.1': {}
-
-  '@types/d3-polygon@3.0.2': {}
-
-  '@types/d3-quadtree@3.0.6': {}
-
-  '@types/d3-random@3.0.3': {}
-
-  '@types/d3-scale-chromatic@3.1.0': {}
-
-  '@types/d3-scale@4.0.9':
-    dependencies:
-      '@types/d3-time': 3.0.4
-
-  '@types/d3-selection@3.0.11': {}
-
-  '@types/d3-shape@3.1.8':
-    dependencies:
-      '@types/d3-path': 3.1.1
-
-  '@types/d3-time-format@4.0.3': {}
-
-  '@types/d3-time@3.0.4': {}
-
-  '@types/d3-timer@3.0.2': {}
-
-  '@types/d3-transition@3.0.9':
-    dependencies:
-      '@types/d3-selection': 3.0.11
-
-  '@types/d3-zoom@3.0.8':
-    dependencies:
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-selection': 3.0.11
-
-  '@types/d3@7.4.3':
-    dependencies:
-      '@types/d3-array': 3.2.2
-      '@types/d3-axis': 3.0.6
-      '@types/d3-brush': 3.0.6
-      '@types/d3-chord': 3.0.6
-      '@types/d3-color': 3.1.3
-      '@types/d3-contour': 3.0.6
-      '@types/d3-delaunay': 6.0.4
-      '@types/d3-dispatch': 3.0.7
-      '@types/d3-drag': 3.0.7
-      '@types/d3-dsv': 3.0.7
-      '@types/d3-ease': 3.0.2
-      '@types/d3-fetch': 3.0.7
-      '@types/d3-force': 3.0.10
-      '@types/d3-format': 3.0.4
-      '@types/d3-geo': 3.1.0
-      '@types/d3-hierarchy': 3.1.7
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-path': 3.1.1
-      '@types/d3-polygon': 3.0.2
-      '@types/d3-quadtree': 3.0.6
-      '@types/d3-random': 3.0.3
-      '@types/d3-scale': 4.0.9
-      '@types/d3-scale-chromatic': 3.1.0
-      '@types/d3-selection': 3.0.11
-      '@types/d3-shape': 3.1.8
-      '@types/d3-time': 3.0.4
-      '@types/d3-time-format': 4.0.3
-      '@types/d3-timer': 3.0.2
-      '@types/d3-transition': 3.0.9
-      '@types/d3-zoom': 3.0.8
-
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree-jsx@1.0.5':
@@ -4563,8 +4188,6 @@ snapshots:
       '@types/estree': 1.0.9
 
   '@types/estree@1.0.9': {}
-
-  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -5084,8 +4707,6 @@ snapshots:
 
   commander@11.1.0: {}
 
-  commander@7.2.0: {}
-
   common-ancestor-path@2.0.0: {}
 
   configstore@7.1.0:
@@ -5143,158 +4764,6 @@ snapshots:
     dependencies:
       css-tree: 2.2.1
 
-  d3-array@3.2.4:
-    dependencies:
-      internmap: 2.0.3
-
-  d3-axis@3.0.0: {}
-
-  d3-brush@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-
-  d3-chord@3.0.1:
-    dependencies:
-      d3-path: 3.1.0
-
-  d3-color@3.1.0: {}
-
-  d3-contour@4.0.2:
-    dependencies:
-      d3-array: 3.2.4
-
-  d3-delaunay@6.0.4:
-    dependencies:
-      delaunator: 5.0.1
-
-  d3-dispatch@3.0.1: {}
-
-  d3-drag@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-selection: 3.0.0
-
-  d3-dsv@3.0.1:
-    dependencies:
-      commander: 7.2.0
-      iconv-lite: 0.6.3
-      rw: 1.3.3
-
-  d3-ease@3.0.1: {}
-
-  d3-fetch@3.0.1:
-    dependencies:
-      d3-dsv: 3.0.1
-
-  d3-force@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-quadtree: 3.0.1
-      d3-timer: 3.0.1
-
-  d3-format@3.1.2: {}
-
-  d3-geo@3.1.1:
-    dependencies:
-      d3-array: 3.2.4
-
-  d3-hierarchy@3.1.2: {}
-
-  d3-interpolate@3.0.1:
-    dependencies:
-      d3-color: 3.1.0
-
-  d3-path@3.1.0: {}
-
-  d3-polygon@3.0.1: {}
-
-  d3-quadtree@3.0.1: {}
-
-  d3-random@3.0.1: {}
-
-  d3-scale-chromatic@3.1.0:
-    dependencies:
-      d3-color: 3.1.0
-      d3-interpolate: 3.0.1
-
-  d3-scale@4.0.2:
-    dependencies:
-      d3-array: 3.2.4
-      d3-format: 3.1.2
-      d3-interpolate: 3.0.1
-      d3-time: 3.1.0
-      d3-time-format: 4.1.0
-
-  d3-selection@3.0.0: {}
-
-  d3-shape@3.2.0:
-    dependencies:
-      d3-path: 3.1.0
-
-  d3-time-format@4.1.0:
-    dependencies:
-      d3-time: 3.1.0
-
-  d3-time@3.1.0:
-    dependencies:
-      d3-array: 3.2.4
-
-  d3-timer@3.0.1: {}
-
-  d3-transition@3.0.1(d3-selection@3.0.0):
-    dependencies:
-      d3-color: 3.1.0
-      d3-dispatch: 3.0.1
-      d3-ease: 3.0.1
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-timer: 3.0.1
-
-  d3-zoom@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-
-  d3@7.9.0:
-    dependencies:
-      d3-array: 3.2.4
-      d3-axis: 3.0.0
-      d3-brush: 3.0.0
-      d3-chord: 3.0.1
-      d3-color: 3.1.0
-      d3-contour: 4.0.2
-      d3-delaunay: 6.0.4
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-dsv: 3.0.1
-      d3-ease: 3.0.1
-      d3-fetch: 3.0.1
-      d3-force: 3.0.0
-      d3-format: 3.1.2
-      d3-geo: 3.1.1
-      d3-hierarchy: 3.1.2
-      d3-interpolate: 3.0.1
-      d3-path: 3.1.0
-      d3-polygon: 3.0.1
-      d3-quadtree: 3.0.1
-      d3-random: 3.0.1
-      d3-scale: 4.0.2
-      d3-scale-chromatic: 3.1.0
-      d3-selection: 3.0.0
-      d3-shape: 3.2.0
-      d3-time: 3.1.0
-      d3-time-format: 4.1.0
-      d3-timer: 3.0.1
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-      d3-zoom: 3.0.0
-
   data-uri-to-buffer@4.0.1: {}
 
   debug@4.4.3:
@@ -5308,10 +4777,6 @@ snapshots:
   define-lazy-prop@2.0.0: {}
 
   defu@6.1.7: {}
-
-  delaunator@5.0.1:
-    dependencies:
-      robust-predicates: 3.0.2
 
   delayed-stream@1.0.0: {}
 
@@ -5758,10 +5223,6 @@ snapshots:
       uuid: 8.3.2
       uuid-parse: 1.1.0
 
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -5780,8 +5241,6 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
-
-  internmap@2.0.3: {}
 
   intl-messageformat@10.7.18:
     dependencies:
@@ -6209,7 +5668,7 @@ snapshots:
 
   prettier-plugin-astro@0.14.1:
     dependencies:
-      '@astrojs/compiler': 2.13.0
+      '@astrojs/compiler': 2.13.1
       prettier: 3.9.4
       sass-formatter: 0.7.9
 
@@ -6314,8 +5773,6 @@ snapshots:
 
   robots-parser@3.0.1: {}
 
-  robust-predicates@3.0.2: {}
-
   rolldown@1.1.4:
     dependencies:
       '@oxc-project/types': 0.138.0
@@ -6337,13 +5794,9 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
 
-  rw@1.3.3: {}
-
   s.color@0.0.15: {}
 
   safe-buffer@5.2.1: {}
-
-  safer-buffer@2.1.2: {}
 
   sass-formatter@0.7.9:
     dependencies:


### PR DESCRIPTION
As part of the Starlight Docs move over, I am removing D3 and moving the last chart to the new chart lib. Makes the custom chart components easier to manage in the docs lib.

The style and colour will change in the Starlight move over as the charts use the colours from the Starlight theme

<img width="851" height="641" alt="Screenshot 2026-07-11 at 7 55 40 pm" src="https://github.com/user-attachments/assets/fc0a92fd-3de9-4849-835a-63bb85ba773a" />
