### PR TITLE
Add Package JSON to Stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 .pnp
 .pnp.*
 .yarn/*

--- a/packages/app-astro/stats/5.16.15.json
+++ b/packages/app-astro/stats/5.16.15.json
@@ -139,5 +139,20 @@
         "bytesPerSec": 118718464
       }
     ]
+  },
+  "packageJson": {
+    "dependencies": {
+      "@astrojs/node": "9.5.2",
+      "@astrojs/react": "4.3.0",
+      "astro": "5.16.15",
+      "react": "19.1.0",
+      "react-dom": "19.1.0"
+    },
+    "devDependencies": {
+      "@astrojs/check": "^0.9.6",
+      "@types/react": "^19.2.14",
+      "@types/react-dom": "^19.2.3",
+      "typescript": "^5.9.3"
+    }
   }
 }

--- a/packages/starter-astro/stats/5.16.15.json
+++ b/packages/starter-astro/stats/5.16.15.json
@@ -124,5 +124,14 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "packageJson": {
+    "dependencies": {
+      "astro": "5.16.15"
+    },
+    "devDependencies": {
+      "@astrojs/check": "^0.9.6",
+      "typescript": "^5.9.3"
+    }
   }
 }

--- a/packages/stats-generator/src/save-ci-stats.ts
+++ b/packages/stats-generator/src/save-ci-stats.ts
@@ -3,6 +3,7 @@ import { getFrameworks } from './get-frameworks.ts'
 import { packagesDir } from './constants.ts'
 import {
   getDependencyCountsFromPackageMetadata,
+  getPackageJsonDeps,
   normalizeCIStats,
   readJsonFile,
   writeJsonFile,
@@ -163,6 +164,11 @@ async function main() {
         console.warn(`No e18e stats artifact found at ${e18eArtifactPath}`)
       }
 
+      stats = {
+        ...stats,
+        packageJson: getPackageJsonDeps(packageName),
+      }
+
       // Save to ci-stats.json
       const ciStatsPath = join(packagesDir, packageName, 'ci-stats.json')
       writeJsonFile(ciStatsPath, stats)
@@ -304,6 +310,11 @@ async function main() {
         console.warn(
           `No server-side rendered stats artifact found at ${serverSideRenderedStatsArtifactPath}`,
         )
+      }
+
+      stats = {
+        ...stats,
+        packageJson: getPackageJsonDeps(packageName),
       }
 
       // Save to ci-stats.json

--- a/packages/stats-generator/src/save-stats.ts
+++ b/packages/stats-generator/src/save-stats.ts
@@ -41,5 +41,7 @@ export async function saveStats(
     }
   }
 
-  await writeFile(filePath, JSON.stringify(mergedStats, null, 2), 'utf-8')
+  const { packageJson: _packageJson, ...docsStats } = mergedStats
+
+  await writeFile(filePath, JSON.stringify(docsStats, null, 2), 'utf-8')
 }

--- a/packages/stats-generator/src/types.ts
+++ b/packages/stats-generator/src/types.ts
@@ -109,6 +109,11 @@ export interface CIStats {
     message: string
     fixableBy?: string
   }>
+  // Snapshot of the package.json dependencies at measurement time
+  packageJson?: {
+    dependencies?: Record<string, string>
+    devDependencies?: Record<string, string>
+  }
 }
 
 export interface InstallStats {

--- a/packages/stats-generator/src/utils.ts
+++ b/packages/stats-generator/src/utils.ts
@@ -75,11 +75,20 @@ function countPnpmLockPackages(lockfileContent: string): number {
   return count
 }
 
-export function getDependencyCountsFromPackageMetadata(packageName: string) {
+export function getPackageJsonDeps(packageName: string) {
   const packageJsonPath = join(packagesDir, packageName, 'package.json')
   const packageJson = JSON.parse(
     readFileSync(packageJsonPath, 'utf-8'),
   ) as PackageJson
+
+  return {
+    dependencies: packageJson.dependencies ?? {},
+    devDependencies: packageJson.devDependencies ?? {},
+  }
+}
+
+export function getDependencyCountsFromPackageMetadata(packageName: string) {
+  const { dependencies, devDependencies } = getPackageJsonDeps(packageName)
 
   const lockfilePath = join(packagesDir, packageName, 'pnpm-lock.yaml')
   const allDependencies = existsSync(lockfilePath)
@@ -87,8 +96,8 @@ export function getDependencyCountsFromPackageMetadata(packageName: string) {
     : undefined
 
   return {
-    prodDependencies: Object.keys(packageJson.dependencies ?? {}).length,
-    devDependencies: Object.keys(packageJson.devDependencies ?? {}).length,
+    prodDependencies: Object.keys(dependencies).length,
+    devDependencies: Object.keys(devDependencies).length,
     allDependencies,
   }
 }


### PR DESCRIPTION
We need to save the deps details and package.json stats so that if we ever need to go back to a previous version and re-run tests, we can do so fairly.

Package deps details are stated inside the stats; they never get added to the doc site.

Also added the deps for the older version of Astro that we have since bumped 