### PR TITLE
Removed hard coded version list

### DIFF
--- a/packages/docs/src/content/docs/framework/astro.mdx
+++ b/packages/docs/src/content/docs/framework/astro.mdx
@@ -18,15 +18,8 @@ import {
   getStarterVersionStats,
 } from '../../../lib/collections'
 
-export const astroVersions = ['5.16.15', '5.17.3']
-export const astroStarterVersions = getStarterVersionStats(
-  'starter-astro',
-  astroVersions,
-)
-export const astroRuntimeVersions = getRuntimeVersionStats(
-  'app-astro',
-  astroVersions,
-)
+export const astroStarterVersions = getStarterVersionStats('starter-astro')
+export const astroRuntimeVersions = getRuntimeVersionStats('app-astro')
 
 ## Dev Time
 

--- a/packages/docs/src/lib/collections.ts
+++ b/packages/docs/src/lib/collections.ts
@@ -20,11 +20,7 @@ function compareVersionLabels(a: string, b: string) {
 
 function getVersionedStats<
   T extends { package: string; frameworkVersion?: string },
->(
-  entries: Array<{ data: T }>,
-  packageName: string,
-  versions?: string[],
-) {
+>(entries: Array<{ data: T }>, packageName: string, versions?: string[]) {
   const versionSortOrder =
     versions != null ? getVersionSortOrder(versions) : undefined
 

--- a/packages/docs/src/lib/collections.ts
+++ b/packages/docs/src/lib/collections.ts
@@ -14,10 +14,19 @@ function getVersionSortOrder(versions: string[]) {
   return new Map(versions.map((version, index) => [version, index]))
 }
 
+function compareVersionLabels(a: string, b: string) {
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+}
+
 function getVersionedStats<
   T extends { package: string; frameworkVersion?: string },
->(entries: Array<{ data: T }>, packageName: string, versions: string[]) {
-  const versionSortOrder = getVersionSortOrder(versions)
+>(
+  entries: Array<{ data: T }>,
+  packageName: string,
+  versions?: string[],
+) {
+  const versionSortOrder =
+    versions != null ? getVersionSortOrder(versions) : undefined
 
   return entries
     .map((entry) => entry.data)
@@ -25,25 +34,27 @@ function getVersionedStats<
       (entry) =>
         entry.package === packageName &&
         entry.frameworkVersion != null &&
-        versionSortOrder.has(entry.frameworkVersion),
+        (versionSortOrder == null ||
+          versionSortOrder.has(entry.frameworkVersion)),
     )
-    .sort(
-      (a, b) =>
-        versionSortOrder.get(a.frameworkVersion!)! -
-        versionSortOrder.get(b.frameworkVersion!)!,
+    .sort((a, b) =>
+      versionSortOrder != null
+        ? versionSortOrder.get(a.frameworkVersion!)! -
+          versionSortOrder.get(b.frameworkVersion!)!
+        : compareVersionLabels(a.frameworkVersion!, b.frameworkVersion!),
     )
 }
 
 export function getStarterVersionStats(
   packageName: string,
-  versions: string[],
+  versions?: string[],
 ): DevtimeVersionData[] {
   return getVersionedStats(devtimeVersionEntries, packageName, versions)
 }
 
 export function getRuntimeVersionStats(
   packageName: string,
-  versions: string[],
+  versions?: string[],
 ): RuntimeVersionData[] {
   return getVersionedStats(runtimeVersionEntries, packageName, versions)
 }


### PR DESCRIPTION
Now we have a few versions and the base details page is done we can remove the hard coded list to show