### PR TITLE
Change Load Tests Graphs

### DIFF
--- a/packages/docs/src/components/FrameworkSSRLoadVersionCharts.astro
+++ b/packages/docs/src/components/FrameworkSSRLoadVersionCharts.astro
@@ -9,57 +9,15 @@ const { versions } = Astro.props
 ---
 
 <VersionLineChart
-  title="Peak Requests Per Second"
-  versions={versions}
-  metric="ssrLoadTests.peakRequestsPerSec"
-  valueFormat="count"
-  yAxisLabel="Req/s"
-/>
-<VersionLineChart
-  title="Peak Connections"
-  versions={versions}
-  metric="ssrLoadTests.peakWorkers"
-  valueFormat="count"
-  yAxisLabel="Connections"
-/>
-<VersionLineChart
-  title="Peak Average Latency"
-  versions={versions}
-  metric="ssrLoadTests.peakAvgLatencyMs"
-  valueFormat="ms"
-  yAxisLabel="Milliseconds"
-/>
-<VersionLineChart
-  title="Peak P90 Latency"
-  versions={versions}
-  metric="ssrLoadTests.peakP90LatencyMs"
-  valueFormat="ms"
-  yAxisLabel="Milliseconds"
-/>
-<VersionLineChart
-  title="Peak P99 Latency"
-  versions={versions}
-  metric="ssrLoadTests.peakP99LatencyMs"
-  valueFormat="ms"
-  yAxisLabel="Milliseconds"
-/>
-<VersionLineChart
   title="Total Requests"
   versions={versions}
   metric="ssrLoadTests.totalRequests"
   valueFormat="count"
   yAxisLabel="Requests"
 />
+
 <VersionLineChart
-  title="P90 Latency @ 25 Connections"
-  versions={versions}
-  stageWorkers={25}
-  stageMetric="p90LatencyMs"
-  valueFormat="ms"
-  yAxisLabel="Milliseconds"
-/>
-<VersionLineChart
-  title="P99 Latency @ 25 Connections"
+  title="P99 Latency at 25 Connections"
   versions={versions}
   stageWorkers={25}
   stageMetric="p99LatencyMs"
@@ -67,15 +25,7 @@ const { versions } = Astro.props
   yAxisLabel="Milliseconds"
 />
 <VersionLineChart
-  title="P90 Latency @ 50 Connections"
-  versions={versions}
-  stageWorkers={50}
-  stageMetric="p90LatencyMs"
-  valueFormat="ms"
-  yAxisLabel="Milliseconds"
-/>
-<VersionLineChart
-  title="P99 Latency @ 50 Connections"
+  title="P99 Latency at 50 Connections"
   versions={versions}
   stageWorkers={50}
   stageMetric="p99LatencyMs"
@@ -83,18 +33,60 @@ const { versions } = Astro.props
   yAxisLabel="Milliseconds"
 />
 <VersionLineChart
-  title="P90 Latency @ 100 Connections"
+  title="P99 Latency at 100 Connections"
+  versions={versions}
+  stageWorkers={100}
+  stageMetric="p99LatencyMs"
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>
+
+<VersionLineChart
+  title="P90 Latency at 25 Connections"
+  versions={versions}
+  stageWorkers={25}
+  stageMetric="p90LatencyMs"
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>
+<VersionLineChart
+  title="P90 Latency at 50 Connections"
+  versions={versions}
+  stageWorkers={50}
+  stageMetric="p90LatencyMs"
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>
+<VersionLineChart
+  title="P90 Latency at 100 Connections"
   versions={versions}
   stageWorkers={100}
   stageMetric="p90LatencyMs"
   valueFormat="ms"
   yAxisLabel="Milliseconds"
 />
+
 <VersionLineChart
-  title="P99 Latency @ 100 Connections"
+  title="P75 Latency at 25 Connections"
+  versions={versions}
+  stageWorkers={25}
+  stageMetric="p75LatencyMs"
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>
+<VersionLineChart
+  title="P75 Latency at 50 Connections"
+  versions={versions}
+  stageWorkers={50}
+  stageMetric="p75LatencyMs"
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>
+<VersionLineChart
+  title="P75 Latency at 100 Connections"
   versions={versions}
   stageWorkers={100}
-  stageMetric="p99LatencyMs"
+  stageMetric="p75LatencyMs"
   valueFormat="ms"
   yAxisLabel="Milliseconds"
 />

--- a/packages/docs/src/components/FrameworkSSRRequestThroughputVersionCharts.astro
+++ b/packages/docs/src/components/FrameworkSSRRequestThroughputVersionCharts.astro
@@ -9,23 +9,23 @@ const { versions } = Astro.props
 ---
 
 <VersionLineChart
-  title="SSR Request Throughput"
+  title="Ops/sec"
   versions={versions}
   metric="ssrRequestThroughputTests.opsPerSec"
   valueFormat="count"
-  yAxisLabel="Ops/sec"
+  yAxisLabel="Operations per second"
 />
 <VersionLineChart
-  title="SSR Median Latency"
+  title="Body Size"
+  versions={versions}
+  metric="ssrRequestThroughputTests.bodySizeKb"
+  valueFormat="kb"
+  yAxisLabel="Kilobytes"
+/>
+<VersionLineChart
+  title="Median Latency"
   versions={versions}
   metric="ssrRequestThroughputTests.medianLatencyMs"
   valueFormat="ms"
   yAxisLabel="Milliseconds"
-/>
-<VersionLineChart
-  title="SSR Body Size"
-  versions={versions}
-  metric="ssrRequestThroughputTests.bodySizeKb"
-  valueFormat="kb"
-  yAxisLabel="KB"
 />

--- a/packages/docs/src/components/SSRLoadP75Charts.astro
+++ b/packages/docs/src/components/SSRLoadP75Charts.astro
@@ -1,0 +1,9 @@
+---
+import SSRLoadWorker25P75LatencyChart from './SSRLoadWorker25P75LatencyChart.astro'
+import SSRLoadWorker50P75LatencyChart from './SSRLoadWorker50P75LatencyChart.astro'
+import SSRLoadWorker100P75LatencyChart from './SSRLoadWorker100P75LatencyChart.astro'
+---
+
+<SSRLoadWorker25P75LatencyChart />
+<SSRLoadWorker50P75LatencyChart />
+<SSRLoadWorker100P75LatencyChart />

--- a/packages/docs/src/components/SSRLoadWorker100P75LatencyChart.astro
+++ b/packages/docs/src/components/SSRLoadWorker100P75LatencyChart.astro
@@ -1,0 +1,15 @@
+---
+import { chartSSRLoadWorker100P75LatencyData } from '../lib/collections'
+import ComparisonBarChart from './ComparisonBarChart.astro'
+
+const data = [...chartSSRLoadWorker100P75LatencyData].sort(
+  (a, b) => a.value - b.value || a.name.localeCompare(b.name),
+)
+---
+
+<ComparisonBarChart
+  title="P75 Latency at 100 Connections"
+  data={data}
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>

--- a/packages/docs/src/components/SSRLoadWorker25P75LatencyChart.astro
+++ b/packages/docs/src/components/SSRLoadWorker25P75LatencyChart.astro
@@ -1,0 +1,15 @@
+---
+import { chartSSRLoadWorker25P75LatencyData } from '../lib/collections'
+import ComparisonBarChart from './ComparisonBarChart.astro'
+
+const data = [...chartSSRLoadWorker25P75LatencyData].sort(
+  (a, b) => a.value - b.value || a.name.localeCompare(b.name),
+)
+---
+
+<ComparisonBarChart
+  title="P75 Latency at 25 Connections"
+  data={data}
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>

--- a/packages/docs/src/components/SSRLoadWorker50P75LatencyChart.astro
+++ b/packages/docs/src/components/SSRLoadWorker50P75LatencyChart.astro
@@ -1,0 +1,15 @@
+---
+import { chartSSRLoadWorker50P75LatencyData } from '../lib/collections'
+import ComparisonBarChart from './ComparisonBarChart.astro'
+
+const data = [...chartSSRLoadWorker50P75LatencyData].sort(
+  (a, b) => a.value - b.value || a.name.localeCompare(b.name),
+)
+---
+
+<ComparisonBarChart
+  title="P75 Latency at 50 Connections"
+  data={data}
+  valueFormat="ms"
+  yAxisLabel="Milliseconds"
+/>

--- a/packages/docs/src/content/docs/run-time.mdx
+++ b/packages/docs/src/content/docs/run-time.mdx
@@ -9,6 +9,7 @@ import CoreWebVitalsCharts from '../../components/CoreWebVitalsCharts.astro'
 import CoreWebVitalsTable from '../../components/CoreWebVitalsTable.astro'
 import ServerSideRenderedCharts from '../../components/ServerSideRenderedCharts.astro'
 import ServerSideRenderedStatsTable from '../../components/ServerSideRenderedStatsTable.astro'
+import SSRLoadP75Charts from '../../components/SSRLoadP75Charts.astro'
 import SSRLoadP90Charts from '../../components/SSRLoadP90Charts.astro'
 import SSRLoadP99Charts from '../../components/SSRLoadP99Charts.astro'
 import SSRLoadStatsTable from '../../components/SSRLoadStatsTable.astro'
@@ -53,6 +54,10 @@ Methodology: [Server Side Load Test](/methodology/#server-side-load-test).
 ### P90 Latency
 
 <SSRLoadP90Charts />
+
+### P75 Latency
+
+<SSRLoadP75Charts />
 
 ## Core Web Vitals
 

--- a/packages/docs/src/lib/collections.ts
+++ b/packages/docs/src/lib/collections.ts
@@ -102,7 +102,7 @@ function getSSRLoadLatencyStage(framework: RuntimeData, workers: number) {
 
 function getSSRLoadChartData(
   workers: number,
-  percentile: 'p90LatencyMs' | 'p99LatencyMs',
+  percentile: 'p75LatencyMs' | 'p90LatencyMs' | 'p99LatencyMs',
 ) {
   return runtimeEntries
     .map((entry) => entry.data)
@@ -248,6 +248,18 @@ export const chartSSRLoadWorker50P90LatencyData = getSSRLoadChartData(
 export const chartSSRLoadWorker100P90LatencyData = getSSRLoadChartData(
   100,
   'p90LatencyMs',
+)
+export const chartSSRLoadWorker25P75LatencyData = getSSRLoadChartData(
+  25,
+  'p75LatencyMs',
+)
+export const chartSSRLoadWorker50P75LatencyData = getSSRLoadChartData(
+  50,
+  'p75LatencyMs',
+)
+export const chartSSRLoadWorker100P75LatencyData = getSSRLoadChartData(
+  100,
+  'p75LatencyMs',
 )
 
 export const chartServerSideRenderedFPData = runtimeEntries


### PR DESCRIPTION
Changed the load graphs to match the same ones on the runtime page, showing total requests from the whole test and P75.

I think we should just avoid showing average data from load tests, as it's confusing; it might be worth stripping it from the dataset. Showing graphs at each load stage is much clearer about results.

