### PR TITLE
Tweak the layout styles and reintroduce table of contents

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -15,7 +15,6 @@ export default defineConfig({
       customCss: ['./src/styles/starlight.css'],
       pagefind: false,
       disable404Route: true,
-      tableOfContents: false,
       sidebar: [
         { label: 'Overview', link: '/' },
         { label: 'Dev Time', link: '/dev-time/' },

--- a/packages/docs/src/content/docs/all-frameworks.mdx
+++ b/packages/docs/src/content/docs/all-frameworks.mdx
@@ -22,7 +22,7 @@ import SSRLoadStatsTable from '../../components/SSRLoadStatsTable.astro'
 import SSRRequestThroughputCharts from '../../components/SSRRequestThroughputCharts.astro'
 import SSRRequestThroughputStatsTable from '../../components/SSRRequestThroughputStatsTable.astro'
 
-<div className="benchmark-page" data-framework-scope="all">
+<div data-framework-scope="all">
 
 ## Dependency Counts
 

--- a/packages/docs/src/content/docs/dev-time.mdx
+++ b/packages/docs/src/content/docs/dev-time.mdx
@@ -17,7 +17,7 @@ Each starter project uses each meta-frameworks recommended setup via their CLI w
 
 ### Astro
 
-<div className="benchmark-page" data-framework-scope="focused">
+<div data-framework-scope="focused">
 
 ## Dependency Counts
 

--- a/packages/docs/src/content/docs/run-time.mdx
+++ b/packages/docs/src/content/docs/run-time.mdx
@@ -16,7 +16,7 @@ import SSRLoadStatsTable from '../../components/SSRLoadStatsTable.astro'
 import SSRRequestThroughputCharts from '../../components/SSRRequestThroughputCharts.astro'
 import SSRRequestThroughputStatsTable from '../../components/SSRRequestThroughputStatsTable.astro'
 
-<div className="benchmark-page" data-framework-scope="focused">
+<div data-framework-scope="focused">
 
 ## Client Side Rendered Tests
 

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -20,6 +20,7 @@
 
 :root {
   --sl-content-width: 1120px;
+  --sl-sidebar-width:  256px;
 }
 
 .sl-markdown-content table {

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -47,3 +47,7 @@
   height: 42px;
   width: auto;
 }
+
+.depot p:empty {
+  display: none;
+}

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -23,6 +23,10 @@
   --sl-sidebar-width:  16rem;
 }
 
+.sl-markdown-content :where(p, blockquote, li) {
+  max-width: 45rem;
+}
+
 .sl-markdown-content table {
   display: table;
 }

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -18,20 +18,12 @@
   --ft-chart-grid: color-mix(in srgb, var(--sl-color-gray-4), transparent 45%);
 }
 
-.main-pane .sl-container {
-  max-width: 1120px;
-}
-
-.sl-markdown-content :where(.full-width, .wrapper) {
-  max-width: none;
+:root {
+  --sl-content-width: 1120px;
 }
 
 .sl-markdown-content table {
   display: table;
-}
-
-.benchmark-page {
-  width: 100%;
 }
 
 .depot {

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -19,8 +19,8 @@
 }
 
 :root {
-  --sl-content-width: 1120px;
-  --sl-sidebar-width:  256px;
+  --sl-content-width: 70rem;
+  --sl-sidebar-width:  16rem;
 }
 
 .sl-markdown-content table {

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -20,7 +20,7 @@
 
 :root {
   --sl-content-width: 70rem;
-  --sl-sidebar-width:  16rem;
+  --sl-sidebar-width: 16rem;
 }
 
 .sl-markdown-content :where(p, blockquote, li) {


### PR DESCRIPTION
This PR tweaks the styles that make the main site content render with a wide column width and re-introduces Starlight’s built-in table of contents feature to make it easier to navigate to the sections of each page.

- Uses Starlight’s `--sl-content-width` custom property to increase content column width. This allows other UI elements to adjust appropriately.
- Reduces the sidebar widths slightly to leave more space for the central content on smaller screens.
- Limits the width of body copy to maintain readability.
- Removes some unneeded CSS.
- Fixes the Depot sponsor lock-up on the homepage.

Some before/after screenshots:

| Before | After |
|--------|--------|
| <img width="2880" height="1800" alt="Screen Shot 2026-07-22 at 12 26 44" src="https://github.com/user-attachments/assets/0081e83f-14fc-4688-a0f7-63f3417783b1" /> | <img width="2880" height="1800" alt="Screen Shot 2026-07-22 at 12 26 49" src="https://github.com/user-attachments/assets/bd31574b-b6b8-4025-821f-e045f7dd228f" /> |
| <img width="2184" height="204" alt="image" src="https://github.com/user-attachments/assets/02270561-195d-4236-9812-374c433059cb" /> | <img width="1760" height="144" alt="image" src="https://github.com/user-attachments/assets/9f88cfcf-0c43-440c-8f5a-30b718a8d340" /> | 
| <img width="2880" height="1800" alt="Screen Shot 2026-07-22 at 12 31 01" src="https://github.com/user-attachments/assets/bf6baee9-7066-40b7-8a9e-065f29762243" /> | <img width="2880" height="1800" alt="Screen Shot 2026-07-22 at 12 31 06" src="https://github.com/user-attachments/assets/9050a162-74d8-4937-a5da-ef5dc3b16466" /> |