### PR TITLE
Give the site a lick of paint

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -23,6 +23,13 @@ export default defineConfig({
         { label: 'Methodology', link: '/methodology/' },
         { label: 'Glossary', link: '/glossary/' },
       ],
+      social: [
+        {
+          icon: 'github',
+          label: 'GitHub',
+          href: 'https://github.com/e18e/framework-tracker',
+        },
+      ],
     }),
     mdx(),
   ],

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -9,6 +9,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Framework Tracker',
+      logo: { src: './src/assets/e18e.svg', alt: 'e18e' },
       description:
         'Track and compare framework performance metrics across popular meta-frameworks.',
       favicon: '/favicon.svg',

--- a/packages/docs/public/favicon.svg
+++ b/packages/docs/public/favicon.svg
@@ -1,9 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 128 128">
-    <path d="M50.4 78.5a75.1 75.1 0 0 0-28.5 6.9l24.2-65.7c.7-2 1.9-3.2 3.4-3.2h29c1.5 0 2.7 1.2 3.4 3.2l24.2 65.7s-11.6-7-28.5-7L67 45.5c-.4-1.7-1.6-2.8-2.9-2.8-1.3 0-2.5 1.1-2.9 2.7L50.4 78.5Zm-1.1 28.2Zm-4.2-20.2c-2 6.6-.6 15.8 4.2 20.2a17.5 17.5 0 0 1 .2-.7 5.5 5.5 0 0 1 5.7-4.5c2.8.1 4.3 1.5 4.7 4.7.2 1.1.2 2.3.2 3.5v.4c0 2.7.7 5.2 2.2 7.4a13 13 0 0 0 5.7 4.9v-.3l-.2-.3c-1.8-5.6-.5-9.5 4.4-12.8l1.5-1a73 73 0 0 0 3.2-2.2 16 16 0 0 0 6.8-11.4c.3-2 .1-4-.6-6l-.8.6-1.6 1a37 37 0 0 1-22.4 2.7c-5-.7-9.7-2-13.2-6.2Z" />
-    <style>
-        path { fill: #000; }
-        @media (prefers-color-scheme: dark) {
-            path { fill: #FFF; }
-        }
-    </style>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500">
+  <g filter="url(#a)">
+    <path fill="#7bb560" fill-rule="evenodd" d="M372 154.5h27c1.8 0 4.4 0 6.7.2a31.6 31.6 0 0 1 29 29c.3 2.3.3 5 .3 6.7v115.8h-53.8v77.4h8.7v-68.7h45V395l-.1 6.7a31.6 31.6 0 0 1-29 29c-2.4.2-5 .2-6.8.2h-26.9c-1.8 0-4.4 0-6.7-.2a31.6 31.6 0 0 1-29-29c-.3-2.3-.3-5-.3-6.7V190.4c0-1.8 0-4.4.2-6.7a31.6 31.6 0 0 1 29-29c2.4-.2 5-.2 6.8-.2m9.2 106.7h8.7v-59.3h-8.7z" clip-rule="evenodd"/>
+    <path fill="#bece57" fill-rule="evenodd" d="M264.5 115.8h26.9l6.8.2a31.6 31.6 0 0 1 29 29c.2 2.3.2 4.9.2 6.7V238l-.2 6.7a32 32 0 0 1-7 17.7 32 32 0 0 1 7 17.8c.2 2.3.2 4.9.2 6.7v108.3c0 1.8 0 4.4-.2 6.7-.2 2.8-.8 7.2-3.2 12a32 32 0 0 1-25.8 17c-2.4.2-5 .2-6.8.2h-26.9c-1.8 0-4.4 0-6.7-.2a31.6 31.6 0 0 1-29-29c-.3-2.3-.3-5-.3-6.7V286.8c0-1.8 0-4.4.2-6.7a32 32 0 0 1 7.1-17.8 32 32 0 0 1-7-17.7c-.3-2.3-.3-5-.3-6.7v-86.2c0-1.8 0-4.4.2-6.7a31.6 31.6 0 0 1 29-29c2.4-.2 5-.2 6.8-.2m9.1 47.4v63.2h8.7v-63.2zm0 135v85.4h8.7v-85.3z" clip-rule="evenodd"/>
+    <path fill="#f2ca60" d="M210 98a26.7 26.7 0 0 0-36.5 9.6l-30.7 53a38 38 0 0 0-5.9 12.6 15 15 0 0 0 2.8 10.6c2 2.6 5.1 4.4 11.5 8.1s9.6 5.6 12.7 6q4 .3 7.7-1.2v210.2a40 40 0 0 0 1.3 14.6q2.5 5.7 8.2 8.2a40 40 0 0 0 14.6 1.3c7.8 0 11.6 0 14.7-1.3q5.5-2.5 8.1-8.2c1.3-3 1.3-6.9 1.3-14.6V125.1q0-6.3-.2-9.7a19 19 0 0 0-9.7-17.5"/>
+    <path fill="#ec8f5e" fill-rule="evenodd" d="M100 68c-1.8 0-4.4 0-6.7.2a31.6 31.6 0 0 0-29 29c-.3 2.3-.3 5-.3 6.7v290.8c0 1.8 0 4.4.2 6.7.2 2.8.8 7.2 3.2 12a32 32 0 0 0 25.9 17c2.3.2 4.9.2 6.7.2h26.9c1.8 0 4.4 0 6.7-.2a31.6 31.6 0 0 0 29-29c.3-2.3.3-4.9.3-6.7V272.2h-45.1v111H109V263.5h53.8v-58.4c-2 0-1.8.1-3.2 0-2.2-.3-5.2-1.6-7.4-2.7q-3.1-1.5-7.7-4.2l-.3-.2c-3-1.8-5.5-4-7.5-5.3q-3-2-5-4.6a26 26 0 0 1-3.6-15.7q.5-3.3 2.1-6.4t4.3-7.7l28.3-48.8V104c0-1.8 0-4.4-.2-6.7a31.6 31.6 0 0 0-29-29c-2.4-.2-5-.2-6.8-.2zm17 149.7h-8V115.4h8.8z" clip-rule="evenodd"/>
+  </g>
+  <defs>
+    <filter id="a" width="379" height="371" x="62" y="68" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset dx="2" dy="4"/>
+      <feGaussianBlur stdDeviation="2"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+      <feBlend in2="BackgroundImageFix" result="effect1_dropShadow_47_29"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow_47_29" result="shape"/>
+      <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset dx="-4" dy="-4"/>
+      <feComposite in2="hardAlpha" k2="-1" k3="1" operator="arithmetic"/>
+      <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+      <feBlend in2="shape" result="effect2_innerShadow_47_29"/>
+    </filter>
+  </defs>
 </svg>

--- a/packages/docs/src/assets/e18e.svg
+++ b/packages/docs/src/assets/e18e.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 500 500">
+  <g filter="url(#a)">
+    <path stroke="#7bb560" stroke-width="60" d="M446 304V185c0-5.6 0-8.4-1.1-10.5a10 10 0 0 0-4.4-4.4c-2.1-1.1-5-1.1-10.5-1.1h-33c-5.6 0-8.4 0-10.5 1a10 10 0 0 0-4.4 4.5c-1.1 2.1-1.1 4.9-1.1 10.5v119m65 0h30m-30 0h-65m65 36v83c0 5.6 0 8.4-1.1 10.5a10 10 0 0 1-4.4 4.4c-2.1 1.1-5 1.1-10.5 1.1h-33c-5.6 0-8.4 0-10.5-1a10 10 0 0 1-4.4-4.5c-1.1-2.1-1.1-4.9-1.1-10.5V304"/>
+    <path stroke="#bece57" stroke-width="60" d="M250 136c0-5.6 0-8.4 1-10.5a10 10 0 0 1 4.5-4.4c2.1-1.1 4.9-1.1 10.5-1.1h33c5.6 0 8.4 0 10.5 1a10 10 0 0 1 4.4 4.5c1.1 2.1 1.1 4.9 1.1 10.5v108c0 5.6 0 8.4-1 10.5a10 10 0 0 1-4.5 4.4c-2.1 1.1-4.9 1.1-10.5 1.1h-33c-5.6 0-8.4 0-10.5-1a10 10 0 0 1-4.4-4.5c-1.1-2.1-1.1-4.9-1.1-10.5zm0 171c0-5.6 0-8.4 1-10.5a10 10 0 0 1 4.5-4.4c2.1-1.1 4.9-1.1 10.5-1.1h33c5.6 0 8.4 0 10.5 1a10 10 0 0 1 4.4 4.5c1.1 2.1 1.1 4.9 1.1 10.5v116c0 5.6 0 8.4-1 10.5a10 10 0 0 1-4.5 4.4c-2.1 1.1-4.9 1.1-10.5 1.1h-33c-5.6 0-8.4 0-10.5-1a10 10 0 0 1-4.4-4.5c-1.1-2.1-1.1-4.9-1.1-10.5z"/>
+    <path fill="#f2ca60" d="M202.5 67.4a33.7 33.7 0 0 0-46 12.2l-38.8 67c-4.7 8.1-7 12.1-7.5 16.1a19 19 0 0 0 3.6 13.4c2.3 3.2 6.4 5.6 14.4 10.3 8.1 4.6 12.1 7 16.1 7.4a19 19 0 0 0 9.7-1.4v246.1a49 49 0 0 0 1.7 18.5 20 20 0 0 0 10.3 10.3c3.8 1.7 8.7 1.7 18.5 1.7s14.7 0 18.5-1.7a20 20 0 0 0 10.3-10.3c1.7-3.8 1.7-8.7 1.7-18.5V101.8c0-5.5 0-9.3-.3-12.3.3-8.8-4-17.4-12.2-22.1"/>
+    <path fill="#ec8f5e" fill-rule="evenodd" d="M69.5 30c-2.3 0-5.6 0-8.5.2A40 40 0 0 0 24.2 67c-.2 3-.2 6.2-.2 8.5v348c0 2.3 0 5.6.2 8.5A40 40 0 0 0 61 468.8c3 .2 6.2.2 8.5.2h34c2.3 0 5.6 0 8.5-.2a40 40 0 0 0 36.8-36.8c.2-3 .2-6.2.2-8.5v-139H89V409h-5V279.5h65v-80.7a24 24 0 0 1-5.3 0q-4-.6-8-2.6-4.2-2-9.8-5.4l-.3-.2q-6-3.3-9.6-5.8a25 25 0 0 1-6.3-5.7 24 24 0 0 1-4.5-17q.6-4 2.6-8 2-4.2 5.4-9.8L149 82.6v-7.1c0-2.3 0-5.6-.2-8.5A40 40 0 0 0 112 30.2c-3-.2-6.2-.2-8.5-.2zM89 219.5h-5V90h5z" clip-rule="evenodd"/>
+  </g>
+  <defs>
+    <filter id="a" width="460" height="447" x="22" y="30" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset dx="2" dy="4"/>
+      <feGaussianBlur stdDeviation="2"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+      <feBlend in2="BackgroundImageFix" result="effect1_dropShadow_29_99"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow_29_99" result="shape"/>
+      <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset dx="-4" dy="-4"/>
+      <feComposite in2="hardAlpha" k2="-1" k3="1" operator="arithmetic"/>
+      <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+      <feBlend in2="shape" result="effect2_innerShadow_29_99"/>
+    </filter>
+  </defs>
+</svg>

--- a/packages/docs/src/components/ComparisonBarChart.astro
+++ b/packages/docs/src/components/ComparisonBarChart.astro
@@ -41,15 +41,11 @@ const chartPayload = JSON.stringify({
 >
   .comparison-chart {
     width: 100%;
-    margin-top: 0;
     margin-bottom: 2em;
   }
 
   .comparison-chart-title {
     font-size: 16px;
-    font-weight: 600;
-    color: var(--ft-text);
-    margin: 0 0 0.75em;
   }
 
   .comparison-chart-wrapper {
@@ -57,7 +53,7 @@ const chartPayload = JSON.stringify({
     width: 100%;
     max-width: 1000px;
     height: var(--chartHeight);
-    margin: 0 auto;
+    margin-inline: auto;
   }
 
   @media (max-width: 768px) {

--- a/packages/docs/src/components/DevTimeChart.astro
+++ b/packages/docs/src/components/DevTimeChart.astro
@@ -36,7 +36,6 @@ const chartData = JSON.stringify([
   .dev-time-chart-container {
     position: relative;
     width: 100%;
-    margin-top: 1.5em;
     margin-bottom: 2em;
   }
 
@@ -45,7 +44,7 @@ const chartData = JSON.stringify([
     width: 100%;
     max-width: 1000px;
     height: 600px;
-    margin: 0 auto;
+    margin-inline: auto;
   }
 
   @media (max-width: 768px) {

--- a/packages/docs/src/components/StatsTable.astro
+++ b/packages/docs/src/components/StatsTable.astro
@@ -116,7 +116,7 @@ const { label, columns, data } = Astro.props
   }
 
   tbody tr:hover {
-    background: color-mix(in srgb, var(--ft-accent), transparent 92%);
+    background: color-mix(in srgb, var(--ft-accent-hover), transparent 96%);
   }
 
   .table-link {

--- a/packages/docs/src/components/VersionLineChart.astro
+++ b/packages/docs/src/components/VersionLineChart.astro
@@ -116,15 +116,11 @@ const hasChartData = chartData.length > 0
 >
   .version-line-chart {
     width: 100%;
-    margin-top: 0;
     margin-bottom: 2em;
   }
 
   .version-line-chart-title {
     font-size: 16px;
-    font-weight: 600;
-    color: var(--ft-text);
-    margin: 0 0 0.75em;
   }
 
   .version-line-chart-wrapper {
@@ -132,7 +128,7 @@ const hasChartData = chartData.length > 0
     width: 100%;
     max-width: 1000px;
     height: var(--chartHeight);
-    margin: 0 auto;
+    margin-inline: auto;
   }
 
   @media (max-width: 768px) {

--- a/packages/docs/src/content/docs/dev-time.mdx
+++ b/packages/docs/src/content/docs/dev-time.mdx
@@ -15,8 +15,6 @@ import NodeModulesSizeCharts from '../../components/NodeModulesSizeCharts.astro'
 
 Each starter project uses each meta-frameworks recommended setup via their CLI wizard or recommended setup from their docs. You can find the full details inside the Methodology: [Project Setups](/methodology/#project-setups).
 
-### Astro
-
 <div data-framework-scope="focused">
 
 ## Dependency Counts

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -24,6 +24,7 @@
   --ft-chart-grid: var(--sl-color-gray-5);
 }
 
+/* Make main content column wider and sidebars narrower. */
 :root {
   --sl-content-width: 70rem;
   --sl-sidebar-width: 16rem;
@@ -110,6 +111,7 @@ mobile-starlight-toc {
   }
 }
 
+/* Constrain body copy width to improve readability. */
 .sl-markdown-content :where(p, blockquote, li) {
   max-width: 45rem;
 }

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -37,6 +37,79 @@
   }
 }
 
+/* Use the same background colour for sidebar and navigation as rest of page. */
+:root {
+  --sl-color-bg-nav: var(--sl-color-bg);
+  --sl-color-bg-sidebar: var(--sl-color-bg);
+}
+/* Remove borders around various UI elements. */
+.header {
+  border-bottom: 0;
+}
+.sidebar-pane {
+  border-inline-end: 0;
+}
+.right-sidebar {
+  border-inline-start: 0;
+}
+mobile-starlight-toc summary {
+  border-bottom: 0;
+}
+.content-panel {
+  padding-block: 0.5rem;
+  & + .content-panel {
+    border-top: 0;
+  }
+}
+
+/* Use less prominent current-page styling in sidebar navigation. */
+.sidebar-content [aria-current='page'] {
+  color: var(--sl-color-text-accent);
+  background-color: transparent;
+}
+
+/* Make table of contents heading smaller. */
+.right-sidebar h2 {
+  font-size: var(--sl-text-sm);
+}
+/* Align left edge of table of contents with “On this page” heading. */
+.right-sidebar-panel a {
+  --pad-inline: 0px;
+}
+
+/* Customize mobile table of contents display. */
+mobile-starlight-toc {
+  details {
+    height: var(--sl-mobile-toc-height);
+  }
+  [open]::details-content {
+    width: max-content;
+    min-width: min(17rem, 100%);
+  }
+  [open] .toggle {
+    background-color: var(--sl-color-gray-7, var(--sl-color-gray-6));
+    border-color: var(--sl-color-gray-5);
+  }
+  .dropdown {
+    margin-inline: 1rem;
+    margin-bottom: -0.5rem;
+    border-color: var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    background-color: var(--sl-color-gray-7, var(--sl-color-gray-6));
+  }
+  .isMobile a {
+    --pad-inline: 0.75rem;
+    border-top: 0;
+    padding-block: 0.4375rem;
+  }
+  .isMobile > :first-child a {
+    padding-top: 0.625rem;
+  }
+  .isMobile > :last-child a {
+    padding-bottom: 0.625rem;
+  }
+}
+
 .sl-markdown-content :where(p, blockquote, li) {
   max-width: 45rem;
 }

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -23,6 +23,14 @@
   --sl-sidebar-width: 16rem;
 }
 
+/* Tweak site title lock-up with e18e logo. */
+.site-title {
+  --sl-nav-gap: 0.5em;
+  img {
+    height: 1.25em;
+  }
+}
+
 .sl-markdown-content :where(p, blockquote, li) {
   max-width: 45rem;
 }

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -118,6 +118,7 @@ mobile-starlight-toc {
 
 .sl-markdown-content table {
   display: table;
+  border: 0; /* Remove border in Firefox introduced by display: table */
 }
 
 .depot {

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -1,21 +1,27 @@
+/* Use an e18e-style orange-y accent colour */
 :root {
-  --ft-accent: var(--sl-color-accent);
-  --ft-accent-hover: var(--sl-color-accent-high);
+  --sl-color-accent-low: #371c00;
+  --sl-color-accent: #995800;
+  --sl-color-accent-high: #f0bd90;
+}
+:root[data-theme='light'] {
+  --sl-color-accent-low: #f5cfad;
+  --sl-color-accent: #9b5900;
+  --sl-color-accent-high: #4b2800;
+}
+
+/* Colours used in the benchmark charts. */
+:root {
+  --ft-accent: var(--sl-color-text-accent);
+  --ft-accent-hover: var(--sl-color-white);
   --ft-text: var(--sl-color-text);
   --ft-muted: var(--sl-color-gray-3);
   --ft-border: var(--sl-color-gray-5);
   --ft-bg: var(--sl-color-bg);
   --ft-bg-muted: var(--sl-color-gray-6);
-  --ft-chart-bar: var(--sl-color-accent);
-  --ft-chart-bar-hover: var(--sl-color-accent-high);
-  --ft-chart-grid: color-mix(in srgb, var(--sl-color-gray-3), transparent 68%);
-}
-
-:root[data-theme='light'] {
-  --ft-muted: var(--sl-color-gray-2);
-  --ft-border: var(--sl-color-gray-5);
-  --ft-bg-muted: var(--sl-color-gray-6);
-  --ft-chart-grid: color-mix(in srgb, var(--sl-color-gray-4), transparent 45%);
+  --ft-chart-bar: var(--sl-color-blue);
+  --ft-chart-bar-hover: var(--sl-color-blue-high);
+  --ft-chart-grid: var(--sl-color-gray-5);
 }
 
 :root {


### PR DESCRIPTION
This PR adds some small branding tweaks to the site to make it feel a bit more aligned with other e18e web properties like https://e18e.dev/:

- Adds an e18e logo favicon
- Uses an e18e orange accent for links and other UI details (while keeping the more neutral blue in charts)
- Adds the e18e logo to the site header
- Adds a link to this GitHub repo to the site header
- Applies style customizations to make the site UI a bit more minimalistic (e.g. removing borders, simplifying spacing)

I also fixed two small details in this PR as well:

- Removed a border from the `StatsTable` component that was only rendering in Firefox
- Removed a subheading in the “Dev time” page that I think had been added by mistake

Some before/after comparisons:

| Before | After |
|--------|--------|
| <img width="2880" height="1800" alt="Screen Shot 2026-07-22 at 15 08 01" src="https://github.com/user-attachments/assets/dee05d48-9234-4d18-82c1-1012dbcfc3d2" /> | <img width="2880" height="1800" alt="Screen Shot 2026-07-22 at 15 08 03" src="https://github.com/user-attachments/assets/16871388-0969-4cd6-a897-12238e47ad69" /> |
| <img width="2880" height="1800" alt="Screen Shot 2026-07-22 at 15 08 11" src="https://github.com/user-attachments/assets/bef2ec14-c939-42bc-993d-9654245b512e" /> | <img width="2880" height="1800" alt="Screen Shot 2026-07-22 at 15 08 13" src="https://github.com/user-attachments/assets/d0fe91e5-f40f-4bb9-b97e-5085d3f341a9" /> | 
| <img width="2880" height="1800" alt="Screen Shot 2026-07-22 at 15 10 38" src="https://github.com/user-attachments/assets/54fb0b70-5c22-4eae-b050-553912394ee6" /> | <img width="2880" height="1800" alt="Screen Shot 2026-07-22 at 15 10 41" src="https://github.com/user-attachments/assets/89e92a81-6c7a-4b65-8cef-7e9c7388aa37" />
| <img width="750" height="1334" alt="Screen Shot 2026-07-22 at 15 11 31" src="https://github.com/user-attachments/assets/35299637-d3b6-4581-a5c6-5372e64c4198" /> | <img width="750" height="1334" alt="Screen Shot 2026-07-22 at 15 11 33" src="https://github.com/user-attachments/assets/0531cbb0-a1b4-4a79-b0fa-041711ef015c" />
| <img width="750" height="1334" alt="Screen Shot 2026-07-22 at 15 11 40" src="https://github.com/user-attachments/assets/0033a7b3-12f9-4e5a-8a1a-67459ed6133b" /> | <img width="750" height="1334" alt="Screen Shot 2026-07-22 at 15 11 42" src="https://github.com/user-attachments/assets/108b500c-debf-4dcf-8df7-d07b4397890b" />
