### PR TITLE
chore(docs): add cache headers

### DIFF
--- a/packages/docs/public/_headers
+++ b/packages/docs/public/_headers
@@ -4,3 +4,7 @@
 /_astro/*
   ! Cache-Control
   Cache-Control: public, max-age=31536000, immutable
+
+/favicon.*
+  ! Cache-Control
+  Cache-Control: public, max-age=2592000

--- a/packages/docs/public/_headers
+++ b/packages/docs/public/_headers
@@ -1,0 +1,6 @@
+/*
+  Cache-Control: public, max-age=86400, stale-while-revalidate=86400
+
+/_astro/*
+  ! Cache-Control
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
Added cache headers

24-hour cache for all files

1-year cache with immutable for `/_astro/*`, since these assets are content-addressed/hashed 

1-month cache for the favicon
