### PR TITLE
feat: use brand color for charts

### DIFF
--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -19,8 +19,8 @@
   --ft-border: var(--sl-color-gray-5);
   --ft-bg: var(--sl-color-bg);
   --ft-bg-muted: var(--sl-color-gray-6);
-  --ft-chart-bar: var(--sl-color-blue);
-  --ft-chart-bar-hover: var(--sl-color-blue-high);
+  --ft-chart-bar: var(--sl-color-text-accent);
+  --ft-chart-bar-hover: var(--sl-color-white);
   --ft-chart-grid: var(--sl-color-gray-5);
 }
 


### PR DESCRIPTION

<img width="2156" height="953" alt="image" src="https://github.com/user-attachments/assets/6ff34594-c829-4d93-bc9c-b7a9908f9d6c" />
<img width="2156" height="953" alt="image" src="https://github.com/user-attachments/assets/b7d69eed-c71a-4f66-9f42-2f3ed22ce240" />

let me know what you think, i think it works okay because it more brown than orange

## Checklist

- [x] If updating UI/UX components ensure you have added screenshots or a gif or video of the changes to the PR description
- [ ] If this is a dependabot PR that bumps a metaframework version, ensure that all package versions in the package match the versions installed by the metaframework version being bumped
- [ ] If this is a dependabot PR that bumps a metaframework version in a `starter-*` package, ensure that the deps, and file content matches the output of the metaframeworks recommended starter/default project
