### PR TITLE
Exclude Next.js cache from build output size

### DIFF
--- a/packages/docs/src/content/docs/methodology.md
+++ b/packages/docs/src/content/docs/methodology.md
@@ -71,7 +71,12 @@ Installed using the CLI
 - Build benchmarks run 5 times by default and report average, minimum, and
   maximum duration.
 - Build output size is the total size of the configured production output
-  directory after the final build run.
+  directory after the final build run. For Next.js, `.next/cache` is excluded
+  because it is not a production artifact. Other frameworks also write build
+  caches, but store them under `node_modules`, outside their configured output
+  directories. Those caches therefore still exist but are naturally excluded
+  from the measurement; excluding `.next/cache` keeps the comparison
+  consistent.
 
 ### Core-JS Polyfills
 

--- a/packages/stats-generator/src/run-build-benchmark.ts
+++ b/packages/stats-generator/src/run-build-benchmark.ts
@@ -62,7 +62,14 @@ async function main() {
     console.info(`  Warm build time: ${warmBuildTimeMs}ms`)
   }
 
-  const buildOutputSize = getDirectorySize(buildOutputPath)
+  const excludedBuildOutputPaths =
+    testConfig.buildOutputDir === '.next'
+      ? [join(buildOutputPath, 'cache')]
+      : []
+  const buildOutputSize = getDirectorySize(
+    buildOutputPath,
+    excludedBuildOutputPaths,
+  )
   console.info(`\nBuild output size: ${buildOutputSize} bytes`)
 
   const coldBuildTime = {

--- a/packages/stats-generator/src/utils.ts
+++ b/packages/stats-generator/src/utils.ts
@@ -12,13 +12,28 @@ import type {
 } from './types.ts'
 
 /**
- * Get directory size in bytes using du command.
+ * Get directory size in bytes using du command, optionally excluding subpaths.
  * Works on both Linux and macOS.
  */
-export function getDirectorySize(dirPath: string): number {
+export function getDirectorySize(
+  dirPath: string,
+  excludedPaths: string[] = [],
+): number {
   try {
     const output = execFileSync('du', ['-sk', dirPath], { encoding: 'utf-8' })
-    const sizeKb = Number.parseInt(output.split(/\s+/)[0], 10)
+    let sizeKb = Number.parseInt(output.split(/\s+/)[0], 10)
+
+    for (const excludedPath of excludedPaths) {
+      if (!existsSync(excludedPath)) {
+        continue
+      }
+
+      const excludedOutput = execFileSync('du', ['-sk', excludedPath], {
+        encoding: 'utf-8',
+      })
+      sizeKb -= Number.parseInt(excludedOutput.split(/\s+/)[0], 10)
+    }
+
     return sizeKb * 1024
   } catch (error) {
     console.warn(`Warning: Could not get directory size for ${dirPath}:`, error)


### PR DESCRIPTION
## Summary
- exclude `.next/cache` from Next.js build output size measurements
- support excluded subpaths in the directory size helper
- document why comparable framework caches under `node_modules` are already outside the measurement

## Verification
- `pnpm --filter @framework-tracker/stats-generator type-check`
- `pnpm --filter @framework-tracker/stats-generator lint`
- `pnpm exec prettier --check packages/stats-generator/src/utils.ts packages/stats-generator/src/run-build-benchmark.ts packages/docs/src/content/docs/methodology.md`
- focused directory-size exclusion check