### PR TITLE
Turn on versioning for SolidStart

### DIFF
--- a/packages/docs/src/content/docs/framework/solid-start.md
+++ b/packages/docs/src/content/docs/framework/solid-start.md
@@ -1,7 +1,0 @@
----
-title: SolidStart
-description: SolidStart version comparison page.
----
-
-Versioning has not been turned on for SolidStart yet, so past comparisons are
-not active.

--- a/packages/docs/src/content/docs/framework/solid-start.mdx
+++ b/packages/docs/src/content/docs/framework/solid-start.mdx
@@ -1,0 +1,97 @@
+---
+title: SolidStart
+description: SolidStart version comparison page.
+---
+
+import FrameworkBrowserBaselineVersionTable from '../../../components/FrameworkBrowserBaselineVersionTable.astro'
+import FrameworkBuildInstallVersionCharts from '../../../components/FrameworkBuildInstallVersionCharts.astro'
+import FrameworkClientRenderedVersionCharts from '../../../components/FrameworkClientRenderedVersionCharts.astro'
+import FrameworkCoreJsVersionChart from '../../../components/FrameworkCoreJsVersionChart.astro'
+import FrameworkDependencyVersionCharts from '../../../components/FrameworkDependencyVersionCharts.astro'
+import FrameworkNodeModulesSizeVersionCharts from '../../../components/FrameworkNodeModulesSizeVersionCharts.astro'
+import FrameworkServerRenderedVersionCharts from '../../../components/FrameworkServerRenderedVersionCharts.astro'
+import FrameworkSSRLoadVersionCharts from '../../../components/FrameworkSSRLoadVersionCharts.astro'
+import FrameworkSSRRequestThroughputVersionCharts from '../../../components/FrameworkSSRRequestThroughputVersionCharts.astro'
+import MethodologyLink from '../../../components/MethodologyLink.astro'
+import {
+  getRuntimeVersionStats,
+  getStarterVersionStats,
+} from '../../../lib/collections'
+
+export const solidStartStarterVersions = getStarterVersionStats(
+  'starter-solid-start',
+)
+export const solidStartRuntimeVersions =
+  getRuntimeVersionStats('app-solid-start')
+
+## Dev Time
+
+### Dependency Counts
+
+<MethodologyLink title="Dependency Counts" slug="dependency-counts" />
+
+<FrameworkDependencyVersionCharts versions={solidStartStarterVersions} />
+
+### Node Modules Size
+
+<MethodologyLink title="Node Modules Size" slug="node-modules-size" />
+
+<FrameworkNodeModulesSizeVersionCharts versions={solidStartStarterVersions} />
+
+### Build and Install Times
+
+<MethodologyLink
+  title="Build and Install Times"
+  slug="build-and-install-times"
+/>
+
+<FrameworkBuildInstallVersionCharts versions={solidStartStarterVersions} />
+
+### Core-JS Polyfills
+
+<MethodologyLink title="Core-JS Polyfills" slug="core-js-polyfills" />
+
+<FrameworkCoreJsVersionChart versions={solidStartStarterVersions} />
+
+### Browser Baseline
+
+<MethodologyLink title="Browser Baseline" slug="browser-baseline" />
+
+<FrameworkBrowserBaselineVersionTable versions={solidStartStarterVersions} />
+
+## Run Time
+
+### Client Side Rendered Tests
+
+<MethodologyLink
+  title="Client Side Rendered Tests"
+  slug="client-side-rendered-tests"
+/>
+
+<FrameworkClientRenderedVersionCharts versions={solidStartRuntimeVersions} />
+
+### Server Side Rendered Tests
+
+<MethodologyLink
+  title="Server Side Rendered Tests"
+  slug="server-side-rendered-tests"
+/>
+
+<FrameworkServerRenderedVersionCharts versions={solidStartRuntimeVersions} />
+
+### Server Side Throughput Tests
+
+<MethodologyLink
+  title="Server Side Throughput Tests"
+  slug="server-side-throughput-tests"
+/>
+
+<FrameworkSSRRequestThroughputVersionCharts
+  versions={solidStartRuntimeVersions}
+/>
+
+### Server Side Load Test
+
+<MethodologyLink title="Server Side Load Test" slug="server-side-load-test" />
+
+<FrameworkSSRLoadVersionCharts versions={solidStartRuntimeVersions} />


### PR DESCRIPTION
Replaces the SolidStart placeholder page with the version comparison charts, matching the existing Astro and SvelteKit pages.

The version data was already being collected: `starter-solid-start` and `app-solid-start` both have entries under `content/*/versions/`, with field-for-field the same shape as Astro's, so every chart component works without changes. Only the page was still a placeholder.

