### PR TITLE
Direct Framework Deps

### DIFF
--- a/packages/docs/src/content.config.ts
+++ b/packages/docs/src/content.config.ts
@@ -10,6 +10,12 @@ const timeSchema = z.object({
   maxMs: z.number(),
 })
 
+const dependencyStatsSchema = z.object({
+  prodDependencies: z.number().int().nonnegative(),
+  devDependencies: z.number().int().nonnegative(),
+  allDependencies: z.number().int().nonnegative(),
+})
+
 const devtimeSchema = z.object({
   name: z.string(),
   type: z.string(),
@@ -19,6 +25,7 @@ const devtimeSchema = z.object({
   prodDependencies: z.number(),
   devDependencies: z.number(),
   allDependencies: z.number(),
+  frameworkDependencies: dependencyStatsSchema.optional(),
   installTime: timeSchema,
   coldBuildTime: timeSchema,
   warmBuildTime: timeSchema,

--- a/packages/docs/src/content/devtime/starter-astro.json
+++ b/packages/docs/src/content/devtime/starter-astro.json
@@ -105,5 +105,10 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 53,
+    "devDependencies": 27,
+    "allDependencies": 80
   }
 }

--- a/packages/docs/src/content/devtime/starter-mastro.json
+++ b/packages/docs/src/content/devtime/starter-mastro.json
@@ -38,5 +38,10 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 1,
+    "devDependencies": 0,
+    "allDependencies": 1
   }
 }

--- a/packages/docs/src/content/devtime/starter-next-js.json
+++ b/packages/docs/src/content/devtime/starter-next-js.json
@@ -418,5 +418,10 @@
     "baselineYear": 2022,
     "baselineReason": null,
     "baselineFeatureCount": 46
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 6,
+    "devDependencies": 223,
+    "allDependencies": 229
   }
 }

--- a/packages/docs/src/content/devtime/starter-nuxt.json
+++ b/packages/docs/src/content/devtime/starter-nuxt.json
@@ -360,5 +360,10 @@
     "baselineYear": null,
     "baselineReason": "temporal",
     "baselineFeatureCount": 40
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 57,
+    "devDependencies": 11,
+    "allDependencies": 68
   }
 }

--- a/packages/docs/src/content/devtime/starter-react-router.json
+++ b/packages/docs/src/content/devtime/starter-react-router.json
@@ -90,5 +90,10 @@
     "baselineYear": 2022,
     "baselineReason": null,
     "baselineFeatureCount": 40
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 28,
+    "devDependencies": 22,
+    "allDependencies": 50
   }
 }

--- a/packages/docs/src/content/devtime/starter-solid-start.json
+++ b/packages/docs/src/content/devtime/starter-solid-start.json
@@ -440,5 +440,10 @@
     "baselineYear": 2020,
     "baselineReason": null,
     "baselineFeatureCount": 29
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 15,
+    "devDependencies": 3,
+    "allDependencies": 18
   }
 }

--- a/packages/docs/src/content/devtime/starter-sveltekit.json
+++ b/packages/docs/src/content/devtime/starter-sveltekit.json
@@ -55,5 +55,10 @@
     "baselineYear": 2020,
     "baselineReason": null,
     "baselineFeatureCount": 40
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 12,
+    "devDependencies": 13,
+    "allDependencies": 25
   }
 }

--- a/packages/docs/src/content/devtime/starter-tanstack-start-react.json
+++ b/packages/docs/src/content/devtime/starter-tanstack-start-react.json
@@ -115,5 +115,10 @@
     "baselineYear": 2022,
     "baselineReason": null,
     "baselineFeatureCount": 45
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 8,
+    "devDependencies": 0,
+    "allDependencies": 8
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-astro/5.16.15.json
+++ b/packages/docs/src/content/devtime/versions/starter-astro/5.16.15.json
@@ -129,5 +129,10 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 63,
+    "devDependencies": 34,
+    "allDependencies": 97
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-astro/5.17.3.json
+++ b/packages/docs/src/content/devtime/versions/starter-astro/5.17.3.json
@@ -264,5 +264,10 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 63,
+    "devDependencies": 34,
+    "allDependencies": 97
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-astro/5.18.0.json
+++ b/packages/docs/src/content/devtime/versions/starter-astro/5.18.0.json
@@ -264,5 +264,10 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 63,
+    "devDependencies": 34,
+    "allDependencies": 97
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-astro/6.0.8.json
+++ b/packages/docs/src/content/devtime/versions/starter-astro/6.0.8.json
@@ -109,5 +109,10 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 55,
+    "devDependencies": 31,
+    "allDependencies": 86
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-astro/6.1.10.json
+++ b/packages/docs/src/content/devtime/versions/starter-astro/6.1.10.json
@@ -109,5 +109,10 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 54,
+    "devDependencies": 31,
+    "allDependencies": 85
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-astro/6.2.2.json
+++ b/packages/docs/src/content/devtime/versions/starter-astro/6.2.2.json
@@ -109,5 +109,10 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 55,
+    "devDependencies": 31,
+    "allDependencies": 86
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-astro/6.3.8.json
+++ b/packages/docs/src/content/devtime/versions/starter-astro/6.3.8.json
@@ -109,5 +109,10 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 55,
+    "devDependencies": 32,
+    "allDependencies": 87
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-astro/6.4.8.json
+++ b/packages/docs/src/content/devtime/versions/starter-astro/6.4.8.json
@@ -109,5 +109,10 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 55,
+    "devDependencies": 32,
+    "allDependencies": 87
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-astro/7.0.9.json
+++ b/packages/docs/src/content/devtime/versions/starter-astro/7.0.9.json
@@ -104,5 +104,10 @@
     "baselineYear": null,
     "baselineReason": null,
     "baselineFeatureCount": 0
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 53,
+    "devDependencies": 27,
+    "allDependencies": 80
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-next-js/16.1.1.json
+++ b/packages/docs/src/content/devtime/versions/starter-next-js/16.1.1.json
@@ -417,5 +417,10 @@
     "baselineYear": 2022,
     "baselineReason": null,
     "baselineFeatureCount": 46
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 6,
+    "devDependencies": 223,
+    "allDependencies": 229
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-nuxt/4.2.2.json
+++ b/packages/docs/src/content/devtime/versions/starter-nuxt/4.2.2.json
@@ -359,5 +359,10 @@
     "baselineYear": null,
     "baselineReason": "temporal",
     "baselineFeatureCount": 40
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 57,
+    "devDependencies": 11,
+    "allDependencies": 68
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-react-router/7.10.1.json
+++ b/packages/docs/src/content/devtime/versions/starter-react-router/7.10.1.json
@@ -89,5 +89,10 @@
     "baselineYear": 2022,
     "baselineReason": null,
     "baselineFeatureCount": 40
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 28,
+    "devDependencies": 22,
+    "allDependencies": 50
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-solid-start/1.2.1.json
+++ b/packages/docs/src/content/devtime/versions/starter-solid-start/1.2.1.json
@@ -439,5 +439,10 @@
     "baselineYear": 2020,
     "baselineReason": null,
     "baselineFeatureCount": 29
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 15,
+    "devDependencies": 3,
+    "allDependencies": 18
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-sveltekit/2.49.4.json
+++ b/packages/docs/src/content/devtime/versions/starter-sveltekit/2.49.4.json
@@ -54,5 +54,10 @@
     "baselineYear": 2020,
     "baselineReason": null,
     "baselineFeatureCount": 40
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 13,
+    "devDependencies": 13,
+    "allDependencies": 26
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-sveltekit/2.50.2.json
+++ b/packages/docs/src/content/devtime/versions/starter-sveltekit/2.50.2.json
@@ -54,5 +54,10 @@
     "baselineYear": 2020,
     "baselineReason": null,
     "baselineFeatureCount": 40
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 13,
+    "devDependencies": 13,
+    "allDependencies": 26
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-sveltekit/2.51.0.json
+++ b/packages/docs/src/content/devtime/versions/starter-sveltekit/2.51.0.json
@@ -54,5 +54,10 @@
     "baselineYear": 2020,
     "baselineReason": null,
     "baselineFeatureCount": 40
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 13,
+    "devDependencies": 13,
+    "allDependencies": 26
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-sveltekit/2.52.2.json
+++ b/packages/docs/src/content/devtime/versions/starter-sveltekit/2.52.2.json
@@ -54,5 +54,10 @@
     "baselineYear": 2020,
     "baselineReason": null,
     "baselineFeatureCount": 40
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 12,
+    "devDependencies": 13,
+    "allDependencies": 25
   }
 }

--- a/packages/docs/src/content/devtime/versions/starter-tanstack-start-react/1.145.3.json
+++ b/packages/docs/src/content/devtime/versions/starter-tanstack-start-react/1.145.3.json
@@ -114,5 +114,10 @@
     "baselineYear": 2022,
     "baselineReason": null,
     "baselineFeatureCount": 45
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 8,
+    "devDependencies": 0,
+    "allDependencies": 8
   }
 }

--- a/packages/starter-astro/ci-stats.json
+++ b/packages/starter-astro/ci-stats.json
@@ -108,5 +108,10 @@
       "@astrojs/check": "^0.9.9",
       "typescript": "^6.0.3"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 53,
+    "devDependencies": 27,
+    "allDependencies": 80
   }
 }

--- a/packages/starter-astro/stats/5.16.15.json
+++ b/packages/starter-astro/stats/5.16.15.json
@@ -133,5 +133,10 @@
       "@astrojs/check": "^0.9.6",
       "typescript": "^5.9.3"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 63,
+    "devDependencies": 34,
+    "allDependencies": 97
   }
 }

--- a/packages/starter-astro/stats/5.17.3.json
+++ b/packages/starter-astro/stats/5.17.3.json
@@ -268,5 +268,10 @@
       "@astrojs/check": "^0.9.6",
       "typescript": "^5.9.3"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 63,
+    "devDependencies": 34,
+    "allDependencies": 97
   }
 }

--- a/packages/starter-astro/stats/5.18.0.json
+++ b/packages/starter-astro/stats/5.18.0.json
@@ -268,5 +268,10 @@
       "@astrojs/check": "^0.9.6",
       "typescript": "^5.9.3"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 63,
+    "devDependencies": 34,
+    "allDependencies": 97
   }
 }

--- a/packages/starter-astro/stats/6.0.8.json
+++ b/packages/starter-astro/stats/6.0.8.json
@@ -113,5 +113,10 @@
       "@astrojs/check": "^0.9.8",
       "typescript": "^5.9.3"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 55,
+    "devDependencies": 31,
+    "allDependencies": 86
   }
 }

--- a/packages/starter-astro/stats/6.1.10.json
+++ b/packages/starter-astro/stats/6.1.10.json
@@ -113,5 +113,10 @@
       "@astrojs/check": "^0.9.9",
       "typescript": "^6.0.3"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 54,
+    "devDependencies": 31,
+    "allDependencies": 85
   }
 }

--- a/packages/starter-astro/stats/6.2.2.json
+++ b/packages/starter-astro/stats/6.2.2.json
@@ -113,5 +113,10 @@
       "@astrojs/check": "^0.9.9",
       "typescript": "^6.0.3"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 55,
+    "devDependencies": 31,
+    "allDependencies": 86
   }
 }

--- a/packages/starter-astro/stats/6.3.8.json
+++ b/packages/starter-astro/stats/6.3.8.json
@@ -113,5 +113,10 @@
       "@astrojs/check": "^0.9.9",
       "typescript": "^6.0.3"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 55,
+    "devDependencies": 32,
+    "allDependencies": 87
   }
 }

--- a/packages/starter-astro/stats/6.4.8.json
+++ b/packages/starter-astro/stats/6.4.8.json
@@ -113,5 +113,10 @@
       "@astrojs/check": "^0.9.9",
       "typescript": "^6.0.3"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 55,
+    "devDependencies": 32,
+    "allDependencies": 87
   }
 }

--- a/packages/starter-astro/stats/7.0.9.json
+++ b/packages/starter-astro/stats/7.0.9.json
@@ -108,5 +108,10 @@
       "@astrojs/check": "^0.9.9",
       "typescript": "^6.0.3"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 53,
+    "devDependencies": 27,
+    "allDependencies": 80
   }
 }

--- a/packages/starter-mastro/ci-stats.json
+++ b/packages/starter-mastro/ci-stats.json
@@ -43,5 +43,10 @@
       "@types/node": "^24",
       "typescript": "^5"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 1,
+    "devDependencies": 0,
+    "allDependencies": 1
   }
 }

--- a/packages/starter-next-js/ci-stats.json
+++ b/packages/starter-next-js/ci-stats.json
@@ -427,5 +427,10 @@
       "eslint-config-next": "16.1.1",
       "tailwindcss": "4"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 6,
+    "devDependencies": 223,
+    "allDependencies": 229
   }
 }

--- a/packages/starter-next-js/stats/16.1.1.json
+++ b/packages/starter-next-js/stats/16.1.1.json
@@ -427,5 +427,10 @@
       "eslint-config-next": "16.1.1",
       "tailwindcss": "4"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 6,
+    "devDependencies": 223,
+    "allDependencies": 229
   }
 }

--- a/packages/starter-nuxt/ci-stats.json
+++ b/packages/starter-nuxt/ci-stats.json
@@ -365,5 +365,10 @@
       "@types/node": "22",
       "vue-tsc": "2"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 57,
+    "devDependencies": 11,
+    "allDependencies": 68
   }
 }

--- a/packages/starter-nuxt/stats/4.2.2.json
+++ b/packages/starter-nuxt/stats/4.2.2.json
@@ -365,5 +365,10 @@
       "@types/node": "22",
       "vue-tsc": "2"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 57,
+    "devDependencies": 11,
+    "allDependencies": 68
   }
 }

--- a/packages/starter-react-router/ci-stats.json
+++ b/packages/starter-react-router/ci-stats.json
@@ -104,5 +104,10 @@
       "vite": "7.3.0",
       "vite-tsconfig-paths": "5.1.4"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 28,
+    "devDependencies": 22,
+    "allDependencies": 50
   }
 }

--- a/packages/starter-react-router/stats/7.10.1.json
+++ b/packages/starter-react-router/stats/7.10.1.json
@@ -104,5 +104,10 @@
       "vite": "7.3.0",
       "vite-tsconfig-paths": "5.1.4"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 28,
+    "devDependencies": 22,
+    "allDependencies": 50
   }
 }

--- a/packages/starter-solid-start/ci-stats.json
+++ b/packages/starter-solid-start/ci-stats.json
@@ -444,5 +444,10 @@
       "vinxi": "0.5.11"
     },
     "devDependencies": {}
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 15,
+    "devDependencies": 3,
+    "allDependencies": 18
   }
 }

--- a/packages/starter-solid-start/stats/1.2.1.json
+++ b/packages/starter-solid-start/stats/1.2.1.json
@@ -444,5 +444,10 @@
       "vinxi": "0.5.11"
     },
     "devDependencies": {}
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 15,
+    "devDependencies": 3,
+    "allDependencies": 18
   }
 }

--- a/packages/starter-sveltekit/ci-stats.json
+++ b/packages/starter-sveltekit/ci-stats.json
@@ -61,5 +61,10 @@
       "typescript": "5.9.3",
       "vite": "7.3.1"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 12,
+    "devDependencies": 13,
+    "allDependencies": 25
   }
 }

--- a/packages/starter-sveltekit/stats/2.49.4.json
+++ b/packages/starter-sveltekit/stats/2.49.4.json
@@ -61,5 +61,10 @@
       "typescript": "5.9.3",
       "vite": "7.3.0"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 13,
+    "devDependencies": 13,
+    "allDependencies": 26
   }
 }

--- a/packages/starter-sveltekit/stats/2.50.2.json
+++ b/packages/starter-sveltekit/stats/2.50.2.json
@@ -61,5 +61,10 @@
       "typescript": "5.9.3",
       "vite": "7.3.1"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 13,
+    "devDependencies": 13,
+    "allDependencies": 26
   }
 }

--- a/packages/starter-sveltekit/stats/2.51.0.json
+++ b/packages/starter-sveltekit/stats/2.51.0.json
@@ -61,5 +61,10 @@
       "typescript": "5.9.3",
       "vite": "7.3.1"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 13,
+    "devDependencies": 13,
+    "allDependencies": 26
   }
 }

--- a/packages/starter-sveltekit/stats/2.52.2.json
+++ b/packages/starter-sveltekit/stats/2.52.2.json
@@ -61,5 +61,10 @@
       "typescript": "5.9.3",
       "vite": "7.3.1"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 12,
+    "devDependencies": 13,
+    "allDependencies": 25
   }
 }

--- a/packages/starter-tanstack-start-react/ci-stats.json
+++ b/packages/starter-tanstack-start-react/ci-stats.json
@@ -139,5 +139,10 @@
       "vitest": "3.2.4",
       "web-vitals": "5.1.0"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 8,
+    "devDependencies": 0,
+    "allDependencies": 8
   }
 }

--- a/packages/starter-tanstack-start-react/stats/1.145.3.json
+++ b/packages/starter-tanstack-start-react/stats/1.145.3.json
@@ -139,5 +139,10 @@
       "vitest": "3.2.4",
       "web-vitals": "5.1.0"
     }
+  },
+  "frameworkDependencies": {
+    "prodDependencies": 8,
+    "devDependencies": 0,
+    "allDependencies": 8
   }
 }

--- a/packages/stats-generator/src/collect-stats.ts
+++ b/packages/stats-generator/src/collect-stats.ts
@@ -4,7 +4,10 @@ import { getFrameworks } from './get-frameworks.ts'
 import { packagesDir } from './constants.ts'
 import { saveStats } from './save-stats.ts'
 import { getCIStats } from './get-ci-stats.ts'
-import { getDependencyCountsFromPackageMetadata } from './utils.ts'
+import {
+  getDependencyCountsFromPackageMetadata,
+  getFrameworkDependencyCountsFromPackageMetadata,
+} from './utils.ts'
 import type {
   BrowserBaselineStats,
   FrameworkStats,
@@ -46,6 +49,16 @@ async function processStarter(framework: FrameworkConfig, order: number) {
       ciStats.allDependencies === undefined)
       ? getDependencyCountsFromPackageMetadata(pkgDir)
       : {}
+  const frameworkDependencyStats =
+    hasDependencies && ciStats.frameworkDependencies === undefined
+      ? {
+          frameworkDependencies:
+            getFrameworkDependencyCountsFromPackageMetadata(
+              pkgDir,
+              framework.frameworkPackage,
+            ),
+        }
+      : {}
   const hasBrowserBaseline = measurements.some(
     (m) => m.type === 'browserBaseline',
   )
@@ -61,6 +74,7 @@ async function processStarter(framework: FrameworkConfig, order: number) {
     isFocused: framework.focusedFramework,
     order,
     ...dependencyStats,
+    ...frameworkDependencyStats,
     ...browserBaselineStats,
     ...ciStats,
   }

--- a/packages/stats-generator/src/save-ci-stats.ts
+++ b/packages/stats-generator/src/save-ci-stats.ts
@@ -3,6 +3,7 @@ import { getFrameworks } from './get-frameworks.ts'
 import { packagesDir } from './constants.ts'
 import {
   getDependencyCountsFromPackageMetadata,
+  getFrameworkDependencyCountsFromPackageMetadata,
   getPackageJsonDeps,
   normalizeCIStats,
   readJsonFile,
@@ -150,9 +151,15 @@ async function main() {
           devDependencies: e18eStats.stats.dependencyCount.development,
           allDependencies: packageDependencyCounts.allDependencies,
         }
+        const frameworkDependencies =
+          getFrameworkDependencyCountsFromPackageMetadata(
+            packageName,
+            framework.frameworkPackage,
+          )
         stats = {
           ...stats,
           ...dependencyCounts,
+          frameworkDependencies,
           duplicateDependencies:
             typeof duplicateEntry?.value === 'number'
               ? duplicateEntry.value

--- a/packages/stats-generator/src/types.ts
+++ b/packages/stats-generator/src/types.ts
@@ -103,6 +103,7 @@ export interface CIStats {
   prodDependencies?: number
   devDependencies?: number
   allDependencies?: number
+  frameworkDependencies?: DependencyStats
   duplicateDependencies?: number
   depInstallSize?: number
   e18eMessages?: Array<{
@@ -115,6 +116,12 @@ export interface CIStats {
     dependencies?: Record<string, string>
     devDependencies?: Record<string, string>
   }
+}
+
+export interface DependencyStats {
+  prodDependencies: number
+  devDependencies: number
+  allDependencies: number
 }
 
 export interface InstallStats {

--- a/packages/stats-generator/src/utils.ts
+++ b/packages/stats-generator/src/utils.ts
@@ -6,6 +6,7 @@ import { packagesDir } from './constants.ts'
 import { getFrameworks } from './get-frameworks.ts'
 import type {
   CIStats,
+  DependencyStats,
   FrameworkConfig,
   PackageJson,
   TestConfig,
@@ -114,6 +115,35 @@ export function getDependencyCountsFromPackageMetadata(packageName: string) {
     prodDependencies: Object.keys(dependencies).length,
     devDependencies: Object.keys(devDependencies).length,
     allDependencies,
+  }
+}
+
+export function getFrameworkDependencyCountsFromPackageMetadata(
+  starterPackageName: string,
+  frameworkPackage: string,
+): DependencyStats {
+  // pnpm exposes JSR dependencies under their package name in node_modules.
+  const installedPackageName = frameworkPackage.replace(/^jsr:/, '')
+  const packageJsonPath = join(
+    packagesDir,
+    starterPackageName,
+    'node_modules',
+    installedPackageName,
+    'package.json',
+  )
+  const packageJson = JSON.parse(
+    readFileSync(packageJsonPath, 'utf-8'),
+  ) as PackageJson
+  const dependencies = packageJson.dependencies ?? {}
+  const devDependencies = packageJson.devDependencies ?? {}
+
+  return {
+    prodDependencies: Object.keys(dependencies).length,
+    devDependencies: Object.keys(devDependencies).length,
+    allDependencies: new Set([
+      ...Object.keys(dependencies),
+      ...Object.keys(devDependencies),
+    ]).size,
   }
 }
 


### PR DESCRIPTION
Current E18E CLI measures deps of the starter project. It would also be good to measure the direct dependencies of the meta-frameworks themselves.

Will also create some new charts and tables and split up the current one once this is merged.