### PR TITLE
chore: fix cwv link to solid-start

### DIFF
--- a/packages/cwv-stats/src/cwv/cwv.ts
+++ b/packages/cwv-stats/src/cwv/cwv.ts
@@ -17,6 +17,10 @@ type FrameworkCWV = {
   }
 }
 
+const frameworkSlugOverrides: Partial<Record<Framework, string>> = {
+  SolidStart: 'solid-start',
+}
+
 export async function getLatestFrameworksCWV(): Promise<Array<FrameworkCWV>> {
   console.info(`Running LCP Query for frameworks: [${frameworks.join(',')}]`)
 
@@ -72,7 +76,9 @@ function validateAllCWVIsSameDate(
 
 function buildFrameworkCWV(latestFrameworkCWV: HTTPArchiveCWVSnapshot[]) {
   const frameworkVitals = latestFrameworkCWV.map((stat) => ({
-    id: stat.technology.toLowerCase().replace(/[.\s]/g, '-'),
+    id:
+      frameworkSlugOverrides[stat.technology] ??
+      stat.technology.toLowerCase().replace(/[.\s]/g, '-'),
     framework: stat.technology,
     date: stat.date,
     overall: getCWV('overall', stat),

--- a/packages/docs/src/content/cwv/cwv-stats.json
+++ b/packages/docs/src/content/cwv/cwv-stats.json
@@ -145,7 +145,7 @@
     }
   },
   {
-    "id": "solidstart",
+    "id": "solid-start",
     "framework": "SolidStart",
     "date": "2026-05-01",
     "overall": {


### PR DESCRIPTION
the link in this table to SolidStart is broken because it links `/solidstart` and it should be `/solid-start`

https://frameworks.e18e.dev/run-time/#core-web-vitals