### PR TITLE
fix(ci): run node-engines scan where dependencies are installed

### DIFF
--- a/.github/workflows/measure-framework.yml
+++ b/.github/workflows/measure-framework.yml
@@ -110,9 +110,6 @@ jobs:
         if: contains(toJson(matrix.framework.measurements), 'browserBaseline')
         run: pnpm --filter @framework-tracker/stats-generator run:browser-baseline ${{ matrix.framework.package }}
 
-      - name: Scan installed dependencies for Node engine constraints
-        run: pnpm --filter @framework-tracker/stats-generator run:node-engines ${{ matrix.framework.package }}
-
       - name: Upload build stats
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -137,14 +134,6 @@ jobs:
           path: packages/${{ matrix.framework.package }}/browser-baseline-stats.json
           retention-days: 1
           if-no-files-found: error
-
-      - name: Upload node engines stats
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: node-engines-stats-${{ matrix.framework.name }}
-          path: packages/${{ matrix.framework.package }}/node-engines-stats.json
-          retention-days: 1
-          if-no-files-found: warn
 
   measure-ssr-request-throughput:
     if: inputs.ssr-request-throughput-matrix != '[]'
@@ -208,6 +197,9 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
 
+      - name: Install stats-generator dependencies
+        run: pnpm install --frozen-lockfile --filter @framework-tracker/stats-generator
+
       - name: Install package dependencies
         working-directory: ./packages/${{ matrix.framework.package }}
         run: pnpm install --frozen-lockfile
@@ -221,6 +213,9 @@ jobs:
           STARTER_PACKAGE: ${{ matrix.framework.package }}
         run: node packages/stats-generator/src/run-framework-dependency-scan.ts "$STARTER_PACKAGE"
 
+      - name: Scan installed dependencies for Node engine constraints
+        run: pnpm --filter @framework-tracker/stats-generator run:node-engines ${{ matrix.framework.package }}
+
       - name: Upload dependency stats
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -228,6 +223,14 @@ jobs:
           path: |
             packages/${{ matrix.framework.package }}/e18e-stats.json
             packages/${{ matrix.framework.package }}/framework-dependency-stats.json
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload node engines stats
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: node-engines-stats-${{ matrix.framework.name }}
+          path: packages/${{ matrix.framework.package }}/node-engines-stats.json
           retention-days: 1
           if-no-files-found: error
 

--- a/packages/stats-generator/src/run-node-engines-scan.ts
+++ b/packages/stats-generator/src/run-node-engines-scan.ts
@@ -109,6 +109,12 @@ async function main() {
 
   const starterDir = join(packagesDir, packageName)
   const nodeModulesDir = join(starterDir, 'node_modules')
+  if (!isRealDirectory(nodeModulesDir)) {
+    throw new Error(
+      `No node_modules in ${starterDir}; install the starter's dependencies before scanning`,
+    )
+  }
+
   const pnpmDir = join(nodeModulesDir, '.pnpm')
 
   const packageDirs = isRealDirectory(pnpmDir)


### PR DESCRIPTION
fixes the min node table showing dashes for everything except mastro and solidstart. turns out #406 moved the build benchmark into a temp copy that gets deleted after the run, so `packages/<starter>/node_modules` no longer exists in `measure-build`, and the scan i added in #414 reads exactly that dir, finds nothing, and falls back to the starter's own `package.json`. 