### PR TITLE
React Router Sign Off

### DIFF
--- a/packages/app-react-router/react-router.config.ts
+++ b/packages/app-react-router/react-router.config.ts
@@ -2,4 +2,11 @@ import type { Config } from '@react-router/dev/config'
 
 export default {
   ssr: true,
+  future: {
+    v8_middleware: true,
+    v8_splitRouteModules: true,
+    v8_viteEnvironmentApi: true,
+    // v8_passThroughRequests: true, // Supported from React Router 7.15
+    // v8_trailingSlashAwareDataRequests: true, // Supported from React Router 7.16
+  },
 } satisfies Config

--- a/packages/starter-react-router/react-router.config.ts
+++ b/packages/starter-react-router/react-router.config.ts
@@ -4,4 +4,11 @@ export default {
   // Config options...
   // Server-side render by default, to enable SPA mode set this to `false`
   ssr: true,
+  future: {
+    v8_middleware: true,
+    v8_splitRouteModules: true,
+    v8_viteEnvironmentApi: true,
+    // v8_passThroughRequests: true, // Supported from React Router 7.15
+    // v8_trailingSlashAwareDataRequests: true, // Supported from React Router 7.16
+  },
 } satisfies Config


### PR DESCRIPTION
For React Router to be signed off we just needed to add some config settings they recommend using.

Two are not ready in this version, but as we bump versions once this PR is in, we can uncomment them

Closes: https://github.com/e18e/framework-tracker/issues/197